### PR TITLE
GitHub Actions による自動テスト実行

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,22 @@
+name: pytest
+
+on: [push, pull_request]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+        poetry-version: [1.0, 1.1.6]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run image
+        uses: abatilo/actions-poetry@v2.1.2
+        with:
+          poetry-version: ${{ matrix.poetry-version }}
+      - name: Run Tests
+        run: poetry run pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        poetry-version: [1.0, 1.1.6]
+        poetry-version: [1.1.6]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,9 +14,13 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Run image
+      - name: Install Poetry
         uses: abatilo/actions-poetry@v2.1.2
         with:
           poetry-version: ${{ matrix.poetry-version }}
+      - name: Set up Poetry virtualenv
+        run: poetry env use python${{ matrix.python-version }}
+      - name: Install dependency libraries
+        run: poetry install
       - name: Run Tests
         run: poetry run pytest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![pytest](https://github.com/MtkN1/pybotters/actions/workflows/pytest.yml/badge.svg)](https://github.com/MtkN1/pybotters/actions/workflows/pytest.yml)
+
 # [BETA] pybotters
 
 An advanced api client for python botters.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,7 +41,7 @@ async def test_client_open(mocker: pytest_mock.MockerFixture):
         'name2': tuple(['key2', 'secret2'.encode()]),
         'name3': tuple(['key3', 'secret3'.encode()]),
     }
-    m.assert_called_once_with('/path/to/apis.json', encoding='utf-8')
+    m.assert_called_once_with(apis)
 
 
 async def test_client_warn(mocker: pytest_mock.MockerFixture):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -2,7 +2,7 @@ import pytest_mock
 from yarl import URL
 
 import pybotters.auth
-import pybotters.request
+from pybotters.request import ClientRequest
 
 
 async def test_request_without_auth(mocker: pytest_mock.MockerFixture):
@@ -13,7 +13,7 @@ async def test_request_without_auth(mocker: pytest_mock.MockerFixture):
     mocker.patch.object(pybotters.auth.Hosts, 'items', items)
     m_sesison = mocker.MagicMock()
     m_sesison.__dict__['_apis'] = {}
-    req = pybotters.request.ClientRequest(
+    req = ClientRequest(
         'GET',
         URL('http://example.com'),
         params={'foo': 'bar'},
@@ -32,7 +32,7 @@ async def test_request_with_auth(mocker: pytest_mock.MockerFixture):
     mocker.patch.object(pybotters.auth.Hosts, 'items', items)
     m_sesison = mocker.MagicMock()
     m_sesison.__dict__['_apis'] = {'example': ('key', 'secret'.encode())}
-    req = pybotters.request.ClientRequest(
+    req = ClientRequest(
         'GET',
         URL('http://example.com'),
         params={'foo': 'bar'},


### PR DESCRIPTION
GitHub Actions による自動テスト実行 workflow を追加しました。

pyproject.toml では処理系のバージョンが 3.7 系となっていますが、README の記載では 3.7+ とあったため、Python 3.7系, 3.8系, 3.9系の matrix で実行される形になっています。

合わせて上記全バージョンで失敗するいくつかのテストケースを修正しました。その他一部テストは 3.8系, 3.9系 のみで失敗する様ですが、そちらまで手を入れてしまうと Pull Request の趣旨から外れてしまうため一旦無視しています。