### PR TITLE
DataStore サブクラスインスタンス取得時の型エラーを解決

### DIFF
--- a/pybotters/models/binance.py
+++ b/pybotters/models/binance.py
@@ -37,23 +37,23 @@ class BinanceDataStore(DataStoreInterface):
 
     @property
     def trade(self) -> 'Trade':
-        return self._stores.get('trade')
+        return self.get('trade', Trade)
 
     @property
     def bookticker(self) -> 'BookTicker':
-        return self._stores.get('bookticker')
+        return self.get('bookticker', BookTicker)
 
     @property
     def balance(self) -> 'Balance':
-        return self._stores.get('balance')
+        return self.get('balance', Balance)
 
     @property
     def position(self) -> 'Position':
-        return self._stores.get('position')
+        return self.get('position', Position)
 
     @property
     def order(self) -> 'Order':
-        return self._stores.get('order')
+        return self.get('order', Order)
 
 
 class Trade(DataStore):

--- a/pybotters/models/btcmex.py
+++ b/pybotters/models/btcmex.py
@@ -32,52 +32,52 @@ class BTCMEXDataStore(DataStoreInterface):
 
     @property
     def orderbook(self) -> DataStore:
-        return self._stores.get('orderBookL2')  
+        return self.get('orderBookL2', DataStore)
 
     @property
     def trade(self) -> DataStore:
-        return self._stores.get('trade')
+        return self.get('trade', DataStore)
 
     @property
     def instrument(self) -> DataStore:
-        return self._stores.get('instrument')
+        return self.get('instrument', DataStore)
 
     @property
     def liquidation(self) -> DataStore:
-        return self._stores.get('liquidation')
+        return self.get('liquidation', DataStore)
 
     @property
     def quote(self) -> DataStore:
-        return self._stores.get('quote')
+        return self.get('quote', DataStore)
 
     @property
     def order(self) -> DataStore:
-        return self._stores.get('order')
+        return self.get('order', DataStore)
 
     @property
     def execution(self) -> DataStore:
-        return self._stores.get('execution')
+        return self.get('execution', DataStore)
 
     @property
     def position(self) -> DataStore:
-        return self._stores.get('position')
+        return self.get('position', DataStore)
 
     @property
     def margin(self) -> DataStore:
-        return self._stores.get('margin')
+        return self.get('margin', DataStore)
 
     @property
     def positionparam(self) -> DataStore:
-        return self._stores.get('positionParam')
+        return self.get('positionParam', DataStore)
 
     @property
     def clientrisklimit(self) -> DataStore:
-        return self._stores.get('clientRiskLimit')
+        return self.get('clientRiskLimit', DataStore)
 
     @property
     def fundsandbonus(self) -> DataStore:
-        return self._stores.get('fundsAndBonus')
+        return self.get('fundsAndBonus', DataStore)
 
     @property
     def positionautocloseinfo(self) -> DataStore:
-        return self._stores.get('positionAutoCloseInfo')
+        return self.get('positionAutoCloseInfo', DataStore)

--- a/pybotters/models/bybit.py
+++ b/pybotters/models/bybit.py
@@ -92,47 +92,47 @@ class BybitDataStore(DataStoreInterface):
 
     @property
     def orderbook(self) -> 'OrderBook':
-        return self._stores.get('orderbook')
+        return self.get('orderbook', OrderBook)
 
     @property
     def trade(self) -> 'Trade':
-        return self._stores.get('trade')
+        return self.get('trade', Trade)
 
     @property
     def insurance(self) -> 'Insurance':
-        return self._stores.get('insurance')
+        return self.get('insurance', Insurance)
 
     @property
     def instrument(self) -> 'Instrument':
-        return self._stores.get('instrument')
+        return self.get('instrument', Instrument)
 
     @property
     def kline(self) -> 'Kline':
-        return self._stores.get('kline')
+        return self.get('kline', Kline)
 
     @property
     def position_inverse(self) -> 'PositionInverse':
-        return self._stores.get('position_inverse')
+        return self.get('position_inverse', PositionInverse)
 
     @property
     def position_usdt(self) -> 'PositionUSDT':
-        return self._stores.get('position_usdt')
+        return self.get('position_usdt', PositionUSDT)
 
     @property
     def execution(self) -> 'Execution':
-        return self._stores.get('execution')
+        return self.get('execution', Execution)
 
     @property
     def order(self) -> 'Order':
-        return self._stores.get('order')
+        return self.get('order', Order)
 
     @property
     def stoporder(self) -> 'StopOrder':
-        return self._stores.get('stoporder')
+        return self.get('stoporder', StopOrder)
 
     @property
     def wallet(self) -> 'Wallet':
-        return self._stores.get('wallet')
+        return self.get('wallet', Wallet)
 
 
 class OrderBook(DataStore):

--- a/pybotters/models/ftx.py
+++ b/pybotters/models/ftx.py
@@ -58,31 +58,31 @@ class FTXDataStore(DataStoreInterface):
 
     @property
     def ticker(self) -> 'Ticker':
-        return self._stores.get('ticker')
+        return self.get('ticker', Ticker)
 
     @property
     def markets(self) -> 'Markets':
-        return self._stores.get('markets')
+        return self.get('markets', Markets)
 
     @property
     def trades(self) -> 'Trades':
-        return self._stores.get('trades')
+        return self.get('trades', Trades)
 
     @property
     def orderbook(self) -> 'OrderBook':
-        return self._stores.get('orderbook')
+        return self.get('orderbook', OrderBook)
 
     @property
     def fills(self) -> 'Fills':
-        return self._stores.get('fills')
+        return self.get('fills', Fills)
 
     @property
     def orders(self) -> 'Orders':
-        return self._stores.get('orders')
+        return self.get('orders', Orders)
 
     @property
     def positions(self) -> 'Positions':
-        return self._stores.get('positions')
+        return self.get('positions', Positions)
 
 
 class Ticker(DataStore):

--- a/pybotters/store.py
+++ b/pybotters/store.py
@@ -165,7 +165,7 @@ class DataStoreInterface:
         self._stores[name] = datastore_class(keys, data)
 
     def get(self, name: str, type: Type[TDataStore]) -> TDataStore:
-        return cast(type, self._stores[name])
+        return cast(type, self._stores.get(name))
 
     def _onmessage(self, msg: Any, ws: ClientWebSocketResponse) -> None:
         print(msg)

--- a/pybotters/store.py
+++ b/pybotters/store.py
@@ -9,16 +9,12 @@ from .ws import ClientWebSocketResponse
 class DataStore:
     _KEYS = []
     _MAXLEN = 9999
-    _data: Dict[uuid.UUID, Item]
-    _index: Dict[int, uuid.UUID]
-    _keys: Tuple[str, ...]
-    _events: List[asyncio.Event]
 
     def __init__(self, keys: List[str]=[], data: List[Item]=[]) -> None:
-        self._data = {}
-        self._index = {}
-        self._keys = tuple(keys if keys else self._KEYS)
-        self._events = []
+        self._data: Dict[uuid.UUID, Item] = {}
+        self._index: Dict[int, uuid.UUID] = {}
+        self._keys: Tuple[str, ...] = tuple(keys if keys else self._KEYS)
+        self._events: List[asyncio.Event] = []
         self._insert(data)
         if hasattr(self, '_init'):
             getattr(self, '_init')()


### PR DESCRIPTION
ジェネリック型を指定して `Typing.cast` メソッドを摘要した結果を返すヘルパーメソッド `DataStore.get` メソッドを実装し、それを利用する形に変更しました