### PR TITLE
GMO コインの認証処理を修正

### DIFF
--- a/pybotters/auth.py
+++ b/pybotters/auth.py
@@ -154,7 +154,11 @@ class Auth:
         path = '/' + '/'.join(url.parts[2:])
         body = JsonPayload(data) if data else FormData(data)()
         timestamp = str(int(time.time() * 1000))
-        text = f'{timestamp}{method}{path}'.encode() + body._value
+        # PUT and DELETE requests do not require payload inclusion
+        if method == "POST":
+            text = f"{timestamp}{method}{path}".encode() + body._value
+        else:
+            text = f"{timestamp}{method}{path}".encode()
         signature = hmac.new(secret, text, hashlib.sha256).hexdigest()
         kwargs.update({'data': body})
         headers.update(


### PR DESCRIPTION
アクセストークンの延長リクエストが失敗していたため調査したところ、[API ドキュメントの記述](https://api.coin.z.com/docs/?python#api-key)「Signatureの作成API-SIGNは、リクエスト時のUnix Timestamp，HTTPメソッド，リクエストのパス，リクエストボディを文字列として連結したものをHMAC-SHA256形式でAPIシークレットキーを使って署名した結果となります。」は正しくなく、リクエストボディが必要となるのは `POST` リクエストのみであり、`DELETE`, `PUT` リクエストにおいては不要でした。

ドキュメントに記載のサンプルコードでもリクエストボディは未使用となっていました。

- `PUT` の例 https://api.coin.z.com/docs/?python#ws-auth-put
- `DELETE` の例 https://api.coin.z.com/docs/?python#ws-auth-delete

そのため、`POST` メソッドの場合のみリクエストボディを含めて Signature を計算する形に変更しました。