### PR TITLE
bitbank datastore 追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ An advanced api client for python botters.
 | Name | API auth | DataStore | API docs |
 | --- | --- | --- | --- |
 | Bybit | ✅ | ✅ | [LINK](https://bybit-exchange.github.io/docs/inverse) |
-| Binance | ✅ | WIP | [LINK](https://binance-docs.github.io/apidocs/spot/en/) |
+| Binance | ✅ | ✅(USDⓈ-M) | [LINK](https://binance-docs.github.io/apidocs/spot/en/) |
 | FTX | ✅ | ✅ | [LINK](https://docs.ftx.com/) |
 | BTCMEX | ✅ | ✅ | [LINK](https://help.btcmex.com/hc/ja/articles/360035945452-API) |
 | BitMEX | ✅ | WIP | [LINK](https://www.bitmex.com/app/apiOverview) |

--- a/pybotters/__init__.py
+++ b/pybotters/__init__.py
@@ -10,6 +10,7 @@ from .models.btcmex import BTCMEXDataStore
 from .models.bybit import BybitDataStore
 from .models.ftx import FTXDataStore
 from .models.binance import BinanceDataStore
+from .models.bitbank import bitbankDataStore
 from .typedefs import WsJsonHandler, WsStrHandler
 
 __all__: Tuple[str, ...] = (

--- a/pybotters/__init__.py
+++ b/pybotters/__init__.py
@@ -24,6 +24,7 @@ __all__: Tuple[str, ...] = (
     'BybitDataStore',
     'FTXDataStore',
     'BinanceDataStore',
+    'bitbankDataStore',
     'print',
     'print_handler',
 )

--- a/pybotters/models/bitbank.py
+++ b/pybotters/models/bitbank.py
@@ -15,7 +15,7 @@ class bitbankDataStore(DataStoreInterface):
         self.create('transactions', datastore_class=Transactions)
         self.create('depth', datastore_class=Depth)
 
-    def _onmessage(self, msg: Any, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: str, ws: ClientWebSocketResponse) -> None:
         if msg.startswith('42'):
             data_json = json.loads(msg[2:])
             room_name=data_json[1]['room_name']
@@ -68,8 +68,7 @@ class Depth(DataStore):
 
         for boardside, side in tuples:
             for item in data[boardside]:
-                item=[int(item[0]), float(item[1])]
-                if item[1]:
+                if item[1]!='0':
                     self._update([{'pair': pair, 'side': side, 'price': item[0], 'size': item[1]}])
                 else:
                     self._delete([{'pair': pair, 'side': side, 'price': item[0]}])

--- a/pybotters/models/bitbank.py
+++ b/pybotters/models/bitbank.py
@@ -1,0 +1,75 @@
+import asyncio
+from typing import Any, Awaitable, Dict, List
+
+import aiohttp
+
+from ..auth import Auth
+from ..store import DataStore, DataStoreInterface
+from ..typedefs import Item
+from ..ws import ClientWebSocketResponse
+import json
+
+
+class bitbankDataStore(DataStoreInterface):
+    def _init(self) -> None:
+        self.create('transactions', datastore_class=Transactions)
+        self.create('depth', datastore_class=Depth)
+
+    def _onmessage(self, msg: Any, ws: ClientWebSocketResponse) -> None:
+        if msg.startswith('42'):
+            data_json = json.loads(msg[2:])
+            room_name=data_json[1]['room_name']
+            data=data_json[1]['message']['data']
+            if 'transactions' in data:
+                self.transactions._onmessage(room_name, data)
+            elif 'depth' in room_name:
+                self.depth._onmessage(room_name, data)
+
+    @property
+    def transactions(self) -> 'Transactions':
+        return self.get('transactions', Transactions)
+
+    @property
+    def depth(self) -> 'Depth':
+        return self.get('depth', Depth)
+
+class Transactions(DataStore):
+    _MAXLEN = 99999
+
+    def _onmessage(self, room_name: str, data: List[Item]) -> None:
+        data=data['transactions']
+        for item in data:
+            pair=room_name.replace('transactions_','')
+            self._insert([{'pair': pair, **item}])
+
+
+class Depth(DataStore):
+    _KEYS = ['pair', 'side', 'price']
+    _BDSIDE = {'sell': 'asks', 'buy': 'bids'}
+
+    def sorted(self, query: Item={}) -> Dict[str, List[float]]:
+        result = {'asks': [], 'bids': []}
+        for item in self:
+            if all(k in item and query[k] == item[k] for k in query):
+                result[self._BDSIDE[item['side']]].append([item['price'], item['size']])
+        result['asks'].sort(key=lambda x: x[0])
+        result['bids'].sort(key=lambda x: x[0], reverse=True)
+        return result
+
+    def _onmessage(self, room_name: str, data: List[Item]) -> None:
+        if 'whole' in room_name:
+            pair=room_name.replace('depth_whole_','')
+            result = self.find({'pair': pair})
+            self._delete(result)
+            tuples=(('bids', 'buy'), ('asks', 'sell'))
+        else:
+            pair=room_name.replace('depth_diff_','')
+            tuples=(('b', 'buy'), ('a', 'sell'))
+
+        for boardside, side in tuples:
+            for item in data[boardside]:
+                item=[int(item[0]), float(item[1])]
+                if item[1]:
+                    self._update([{'pair': pair, 'side': side, 'price': item[0], 'size': item[1]}])
+                else:
+                    self._delete([{'pair': pair, 'side': side, 'price': item[0]}])

--- a/pybotters/models/bitbank.py
+++ b/pybotters/models/bitbank.py
@@ -1,9 +1,4 @@
-import asyncio
-from typing import Any, Awaitable, Dict, List
-
-import aiohttp
-
-from ..auth import Auth
+from typing import Dict, List
 from ..store import DataStore, DataStoreInterface
 from ..typedefs import Item
 from ..ws import ClientWebSocketResponse

--- a/pybotters/models/bitbank.py
+++ b/pybotters/models/bitbank.py
@@ -71,6 +71,14 @@ class Depth(DataStore):
             for item in data[boardside]:
                 if item[1] != '0':
                     self._update(
-                        [{'pair': pair, 'side': side, 'price': item[0], 'size': item[1]}])
+                        [
+                            {
+                                'pair': pair,
+                                'side': side,
+                                'price': item[0],
+                                'size': item[1],
+                            }
+                        ]
+                    )
                 else:
                     self._delete([{'pair': pair, 'side': side, 'price': item[0]}])

--- a/pybotters/models/bitbank.py
+++ b/pybotters/models/bitbank.py
@@ -20,7 +20,7 @@ class bitbankDataStore(DataStoreInterface):
             data_json = json.loads(msg[2:])
             room_name=data_json[1]['room_name']
             data=data_json[1]['message']['data']
-            if 'transactions' in data:
+            if 'transactions' in room_name:
                 self.transactions._onmessage(room_name, data)
             elif 'depth' in room_name:
                 self.depth._onmessage(room_name, data)

--- a/pybotters/models/bitbank.py
+++ b/pybotters/models/bitbank.py
@@ -18,8 +18,8 @@ class bitbankDataStore(DataStoreInterface):
     def _onmessage(self, msg: str, ws: ClientWebSocketResponse) -> None:
         if msg.startswith('42'):
             data_json = json.loads(msg[2:])
-            room_name=data_json[1]['room_name']
-            data=data_json[1]['message']['data']
+            room_name = data_json[1]['room_name']
+            data = data_json[1]['message']['data']
             if 'transactions' in room_name:
                 self.transactions._onmessage(room_name, data)
             elif 'depth' in room_name:
@@ -33,13 +33,14 @@ class bitbankDataStore(DataStoreInterface):
     def depth(self) -> 'Depth':
         return self.get('depth', Depth)
 
+
 class Transactions(DataStore):
     _MAXLEN = 99999
 
     def _onmessage(self, room_name: str, data: List[Item]) -> None:
-        data=data['transactions']
+        data = data['transactions']
         for item in data:
-            pair=room_name.replace('transactions_','')
+            pair = room_name.replace('transactions_', '')
             self._insert([{'pair': pair, **item}])
 
 
@@ -47,7 +48,7 @@ class Depth(DataStore):
     _KEYS = ['pair', 'side', 'price']
     _BDSIDE = {'sell': 'asks', 'buy': 'bids'}
 
-    def sorted(self, query: Item={}) -> Dict[str, List[float]]:
+    def sorted(self, query: Item = {}) -> Dict[str, List[float]]:
         result = {'asks': [], 'bids': []}
         for item in self:
             if all(k in item and query[k] == item[k] for k in query):
@@ -58,17 +59,18 @@ class Depth(DataStore):
 
     def _onmessage(self, room_name: str, data: List[Item]) -> None:
         if 'whole' in room_name:
-            pair=room_name.replace('depth_whole_','')
+            pair = room_name.replace('depth_whole_', '')
             result = self.find({'pair': pair})
             self._delete(result)
-            tuples=(('bids', 'buy'), ('asks', 'sell'))
+            tuples = (('bids', 'buy'), ('asks', 'sell'))
         else:
-            pair=room_name.replace('depth_diff_','')
-            tuples=(('b', 'buy'), ('a', 'sell'))
+            pair = room_name.replace('depth_diff_', '')
+            tuples = (('b', 'buy'), ('a', 'sell'))
 
         for boardside, side in tuples:
             for item in data[boardside]:
-                if item[1]!='0':
-                    self._update([{'pair': pair, 'side': side, 'price': item[0], 'size': item[1]}])
+                if item[1] != '0':
+                    self._update(
+                        [{'pair': pair, 'side': side, 'price': item[0], 'size': item[1]}])
                 else:
                     self._delete([{'pair': pair, 'side': side, 'price': item[0]}])

--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -99,6 +99,12 @@ class Heartbeat:
             await asyncio.sleep(30.0)
 
     @staticmethod
+    async def bitbank(ws: aiohttp.ClientWebSocketResponse):
+        while not ws.closed:
+            await ws.send_str('2')
+            await asyncio.sleep(15.0)
+
+    @staticmethod
     async def liquid(ws: aiohttp.ClientWebSocketResponse):
         while not ws.closed:
             await ws.send_str('{"event":"pusher:ping","data":{}}')
@@ -227,6 +233,7 @@ class Item:
 class HeartbeatHosts:
     items = {
         'www.btcmex.com': Heartbeat.btcmex,
+        'stream.bitbank.cc': Heartbeat.bitbank,
         'stream.bybit.com': Heartbeat.bybit,
         'stream.bytick.com': Heartbeat.bybit,
         'stream-testnet.bybit.com': Heartbeat.bybit,


### PR DESCRIPTION
# 内容
- bitbank datastore の追加
- public websocketのtransactions, depthに対応
- Heartbeatで15秒ごとに"2"を送信
- FTXのデータストアを流用して作成
- 板情報では通貨ペアのキーをpairとしています（FTXではsymbol)
- （参考）bitbankのwebsocketドキュメント
https://github.com/bitbankinc/bitbank-api-docs/blob/master/public-stream_JP.md
