### PR TITLE
GMO コイン用の DataStore を一部実装する

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -366,7 +366,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.7.4.3"
+version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
 optional = false
@@ -400,7 +400,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "c4ea1fda958289be5add30c573b9cf3d19d296337d8d1613ccaa50b61ca717d0"
+content-hash = "6ae9251e5dbfce1b2a2bd7fcdd86fea92c078edecfd52e8736681056277c4a4a"
 
 [metadata.files]
 aiohttp = [
@@ -673,9 +673,9 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
-    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
-    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
+    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
+    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
 ]
 yarl = [
     {file = "yarl-1.6.3-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:0355a701b3998dcd832d0dc47cc5dedf3874f966ac7f870e0f3a6788d802d434"},

--- a/pybotters/__init__.py
+++ b/pybotters/__init__.py
@@ -11,6 +11,7 @@ from .models.ftx import FTXDataStore
 from .models.binance import BinanceDataStore
 from .models.bitbank import bitbankDataStore
 from .models.bitmex import BitMEXDataStore
+from .models.gmocoin import GMOCoinDataStore
 from .typedefs import WsJsonHandler, WsStrHandler
 
 __all__: Tuple[str, ...] = (
@@ -25,6 +26,7 @@ __all__: Tuple[str, ...] = (
     'BinanceDataStore',
     'bitbankDataStore',
     'BitMEXDataStore',
+    'GMOCoinDataStore',
     'print',
     'print_handler',
 )

--- a/pybotters/models/gmocoin.py
+++ b/pybotters/models/gmocoin.py
@@ -9,9 +9,9 @@ from typing import (
     Dict,
     List,
     Optional,
-    TypedDict,
     cast,
 )
+from typing_extensions import TypedDict
 
 import aiohttp
 from pybotters.store import DataStore, DataStoreInterface

--- a/pybotters/models/gmocoin.py
+++ b/pybotters/models/gmocoin.py
@@ -1,0 +1,617 @@
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import Enum, auto
+from typing import (
+    Any,
+    Awaitable,
+    Dict,
+    List,
+    Optional,
+    TypedDict,
+    cast,
+)
+
+import aiohttp
+from pybotters.store import DataStore, DataStoreInterface
+from pybotters.typedefs import Item
+from pybotters.ws import ClientWebSocketResponse
+
+logger = logging.getLogger(__name__)
+
+
+def parse_datetime(x: Any) -> datetime:
+    if isinstance(x, str):
+        return datetime.strptime(x, "%Y-%m-%dT%H:%M:%S.%f%z")
+    else:
+        raise ValueError(f'x only support str, but {type(x)} passed.')
+
+
+class ApiType(Enum):
+    """
+    API 区分
+    """
+
+    Public = auto()
+    Private = auto()
+
+
+class Channel(Enum):
+    """
+    WebSocket API チャンネル
+    """
+
+    # Public
+    TICKER = auto()
+    ORDER_BOOKS = auto()
+    TRADES = auto()
+    # Private
+    EXECUTION_EVENTS = auto()
+    ORDER_EVENTS = auto()
+    POSITION_EVENTS = auto()
+    POSITION_SUMMARY_EVENTS = auto()
+
+    @staticmethod
+    def from_str(name: str) -> "Channel":
+        if not hasattr(Channel, "_table"):
+            Channel._table = {
+                "ticker": Channel.TICKER,
+                "orderbooks": Channel.ORDER_BOOKS,
+                "trades": Channel.TRADES,
+                "executionEvents": Channel.EXECUTION_EVENTS,
+                "orderEvents": Channel.ORDER_EVENTS,
+                "positionEvents": Channel.POSITION_EVENTS,
+                "positionSummaryEvents": Channel.POSITION_SUMMARY_EVENTS,
+            }
+        return Channel._table[name]
+
+
+class MessageType(Enum):
+    """
+    メッセージタイプ
+    """
+
+    NONE = auto()
+    ER = auto()
+    NOR = auto()
+    ROR = auto()
+    COR = auto()
+    OPR = auto()
+    UPR = auto()
+    ULR = auto()
+    CPR = auto()
+    INIT = auto()
+    UPDATE = auto()
+    PERIODIC = auto()
+
+
+class Symbol(Enum):
+    """
+    取り扱い銘柄
+    """
+
+    BTC = auto()
+    ETH = auto()
+    BCH = auto()
+    LTC = auto()
+    XRP = auto()
+    BTC_JPY = auto()
+    ETH_JPY = auto()
+    BCH_JPY = auto()
+    LTC_JPY = auto()
+    XRP_JPY = auto()
+
+
+class OrderSide(Enum):
+    """
+    売買区分
+    """
+
+    BUY = auto()
+    SELL = auto()
+
+
+class ExecutionType(Enum):
+    """
+    注文タイプ
+    """
+
+    MARKET = auto()
+    LIMIT = auto()
+    STOP = auto()
+
+
+class TimeInForce(Enum):
+    """
+    執行数量条件
+    """
+
+    FAK = auto()
+    FAS = auto()
+    FOK = auto()
+    SOK = auto()
+
+
+class SettleType(Enum):
+    """
+    決済区分
+    """
+
+    OPEN = auto()
+    CLOSE = auto()
+    LOSS_CUT = auto()
+
+
+class OrderType(Enum):
+    """
+    取引区分
+    """
+
+    NORMAL = auto()
+    LOSSCUT = auto()
+
+
+class OrderStatus(Enum):
+    """
+    注文ステータス
+    """
+
+    WAITING = auto()
+    ORDERED = auto()
+    MODIFYING = auto()
+    CANCELLING = auto()
+    CANCELED = auto()
+    EXECUTED = auto()
+    EXPIRED = auto()
+
+
+class CancelType(Enum):
+    """
+    取消区分
+    """
+
+    NONE = auto()
+    USER = auto()
+    POSITION_LOSSCUT = auto()
+    INSUFFICIENT_BALANCE = auto()
+    INSUFFICIENT_MARGIN = auto()
+    ACCOUNT_LOSSCUT = auto()
+    MARGIN_CALL = auto()
+    MARGIN_CALL_LOSSCUT = auto()
+    EXPIRED_FAK = auto()
+    EXPIRED_FOK = auto()
+    EXPIRED_SOK = auto()
+    CLOSED_ORDER = auto()
+    SOK_TAKER = auto()
+    PRICE_LIMIT = auto()
+
+
+@dataclass
+class Ticker(TypedDict):
+    ask: int
+    bid: int
+    high: int
+    last: int
+    low: int
+    symbol: Symbol
+    timestamp: datetime
+    volume: Decimal
+
+
+@dataclass
+class OrderLevel(TypedDict):
+    symbol: Symbol
+    side: OrderSide
+    price: int
+    size: Decimal
+
+
+@dataclass
+class OrderBook(TypedDict):
+    asks: List[OrderLevel]
+    bids: List[OrderLevel]
+    symbol: Symbol
+    timestamp: datetime
+
+
+@dataclass
+class Trade(TypedDict):
+    price: int
+    side: OrderSide
+    size: Decimal
+    timestamp: datetime
+    symbol: Symbol
+
+
+@dataclass
+class Execution(TypedDict):
+    execution_id: int
+    order_id: int
+    symbol: Symbol
+    side: OrderSide
+    settle_type: SettleType
+    size: Decimal
+    price: int
+    timestamp: datetime
+    loss_gain: int
+    fee: int
+    # websocket only
+    position_id: Optional[int]
+    execution_type: Optional[ExecutionType]
+    order_price: Optional[int]
+    order_size: Optional[Decimal]
+    order_executed_size: Optional[Decimal]
+    order_timestamp: Optional[datetime]
+    time_in_force: Optional[str]
+
+
+@dataclass
+class Order(TypedDict):
+    order_id: int
+    symbol: Symbol
+    settle_type: SettleType
+    execution_type: ExecutionType
+    side: OrderSide
+    order_status: OrderStatus
+    order_timestamp: datetime
+    price: int
+    size: Decimal
+    executed_size: Decimal
+    losscut_price: int
+    time_in_force: TimeInForce
+    # websocket only
+    cancel_type: Optional[CancelType]
+
+
+@dataclass
+class Position(TypedDict):
+    position_id: int
+    symbol: Symbol
+    side: OrderSide
+    size: Decimal
+    orderd_size: Decimal
+    price: int
+    loss_gain: int
+    leverage: Decimal
+    losscut_price: int
+    timestamp: datetime
+
+
+@dataclass
+class PositionSummary(TypedDict):
+    symbol: Symbol
+    side: OrderSide
+    average_position_rate: int
+    position_loss_gain: int
+    sum_order_quantity: Decimal
+    sum_position_quantity: Decimal
+    timestamp: datetime
+
+
+class OrderBookStore(DataStore):
+    _KEYS = ["symbol", "side", "price"]
+
+    def sorted(self, query: Item = {}) -> Dict[OrderSide, List[OrderLevel]]:
+        result: Dict[OrderSide, List[OrderLevel]] = {
+            OrderSide.BUY: [],
+            OrderSide.SELL: [],
+        }
+        for item in self:
+            if all(k in item and query[k] == item[k] for k in query):
+                result[item["side"]].append(cast(OrderLevel, item))
+        result[OrderSide.SELL].sort(key=lambda x: x["price"])
+        result[OrderSide.BUY].sort(key=lambda x: x["price"], reverse=True)
+        return result
+
+    def _onmessage(self, mes: OrderBook) -> None:
+        data = mes["asks"] + mes["bids"]
+        result = self.find({"symbol": mes["symbol"]})
+        self._delete(result)
+        self._insert(cast(List[Item], data))
+
+
+class OrderStore(DataStore):
+    syncroot = asyncio.Lock()
+    _KEYS = ["order_id"]
+
+    def _onresponse(self, data: List[Order]) -> None:
+        self._insert(cast(List[Item], data))
+
+    async def _onmessage(self, mes: Order) -> None:
+        async with self.syncroot:
+            if mes["order_status"] in (OrderStatus.WAITING, OrderStatus.ORDERED):
+                self._update([cast(Item, mes)])
+            else:
+                self._delete([cast(Item, mes)])
+
+    async def _onexecution(self, mes: Execution) -> None:
+        async with self.syncroot:
+            current = cast(Order, self.get({"order_id": mes["order_id"]}))
+            if (
+                mes["order_executed_size"]
+                and current
+                and current["executed_size"] < mes["order_executed_size"]
+            ):
+                current["executed_size"] = mes["order_executed_size"]
+                remain = current["size"] - current["executed_size"]
+                if remain == 0:
+                    self._delete([cast(Item, current)])
+                else:
+                    self._update([cast(Item, current)])
+
+
+class ExecutionStore(DataStore):
+    _KEYS = ["execution_id"]
+
+    def sorted(self, query: Item = {}) -> List[Execution]:
+        result = []
+        for item in self:
+            if all(k in item and query[k] == item[k] for k in query):
+                result.append(item)
+        result.sort(key=lambda x: x["execution_id"], reverse=True)
+        return result
+
+    def _onresponse(self, data: List[Execution]) -> None:
+        self._insert(cast(List[Item], data))
+
+    async def _onmessage(self, mes: Execution) -> None:
+        self._insert([cast(Item, mes)])
+
+
+class PositionStore(DataStore):
+    _KEYS = ["position_id"]
+
+    def _onresponse(self, data: List[Position]) -> None:
+        self._update(cast(List[Item], data))
+
+    def _onmessage(self, mes: Position, type: MessageType) -> None:
+        if type == MessageType.OPR:
+            self._insert([cast(Item, mes)])
+        elif type == MessageType.CPR:
+            self._delete([cast(Item, mes)])
+        else:
+            self._update([cast(Item, mes)])
+
+
+class PositionSummaryStore(DataStore):
+    _KEYS = ["symbol", "side"]
+
+    def _onresponse(self, data: List[PositionSummary]) -> None:
+        self._update(cast(List[Item], data))
+
+    def _onmessage(self, mes: PositionSummary) -> None:
+        self._update([cast(Item, mes)])
+
+
+class MessageHelper:
+    @staticmethod
+    def to_tickers(data: List[Item]) -> List["Ticker"]:
+        return [MessageHelper.to_ticker(x) for x in data]
+
+    @staticmethod
+    def to_ticker(data: Item) -> "Ticker":
+        return Ticker(
+            ask=int(data["ask"]),
+            bid=int(data["bid"]),
+            high=int(data["high"]),
+            last=int(data["last"]),
+            low=int(data["low"]),
+            symbol=Symbol[data["symbol"]],
+            timestamp=parse_datetime(data.get("timestamp")),
+            volume=Decimal(data["volume"]),
+        )
+
+    @staticmethod
+    def to_orderbook(data: Item) -> "OrderBook":
+        return OrderBook(
+            asks=[
+                OrderLevel(
+                    symbol=Symbol[data["symbol"]],
+                    side=OrderSide.SELL,
+                    price=int(ol["price"]),
+                    size=Decimal(ol["size"]),
+                )
+                for ol in data["asks"]
+            ],
+            bids=[
+                OrderLevel(
+                    symbol=Symbol[data["symbol"]],
+                    side=OrderSide.BUY,
+                    price=int(ol["price"]),
+                    size=Decimal(ol["size"]),
+                )
+                for ol in data["bids"]
+            ],
+            symbol=Symbol[data["symbol"]],
+            timestamp=parse_datetime(data.get("timestamp")),
+        )
+
+    @staticmethod
+    def to_trades(data: List[Item]) -> List["Trade"]:
+        return [MessageHelper.to_trade(x) for x in data]
+
+    @staticmethod
+    def to_trade(data: Item) -> "Trade":
+        return Trade(
+            price=int(data["price"]),
+            side=OrderSide[data["side"]],
+            size=Decimal(data["size"]),
+            timestamp=parse_datetime(data.get("timestamp")),
+            symbol=Symbol[data["symbol"]],
+        )
+
+    @staticmethod
+    def to_executions(data: List[Item]) -> List["Execution"]:
+        return [MessageHelper.to_execution(x) for x in data]
+
+    @staticmethod
+    def to_execution(data: Item) -> "Execution":
+        return Execution(
+            order_id=data["orderId"],
+            execution_id=data["executionId"],
+            symbol=Symbol[data["symbol"]],
+            settle_type=SettleType[data["settleType"]],
+            side=OrderSide[data["side"]],
+            price=int(data.get("executionPrice", data.get("price"))),
+            size=Decimal(data.get("executionSize", data.get("size"))),
+            timestamp=parse_datetime(
+                data.get("executionTimestamp", data.get("timestamp"))
+            ),
+            loss_gain=int(data["lossGain"]),
+            fee=int(data["fee"]),
+            # properties that only appears websocket message
+            position_id=int(data["positionId"]) if "positionId" in data else None,
+            execution_type=ExecutionType[data["executionType"]]
+            if "executionType" in data
+            else None,
+            order_price=int(data["orderPrice"]) if "orderPrice" in data else None,
+            order_size=Decimal(data["orderSize"]) if ("orderSize" in data) else None,
+            order_executed_size=Decimal(data["orderExecutedSize"])
+            if "orderExecutedSize" in data
+            else None,
+            order_timestamp=parse_datetime(data["orderTimestamp"])
+            if "orderTimestamp" in data
+            else None,
+            time_in_force=data.get("timeInForce", None),
+        )
+
+    @staticmethod
+    def to_orders(data: List[Item]) -> List["Order"]:
+        return [MessageHelper.to_order(x) for x in data]
+
+    @staticmethod
+    def to_order(data: Item) -> "Order":
+        status = OrderStatus[data.get("status", data.get("orderStatus"))]
+        timestamp = parse_datetime(data.get("orderTimestamp", data.get("timestamp")))
+        return Order(
+            order_id=data["orderId"],
+            symbol=Symbol[data["symbol"]],
+            settle_type=SettleType[data["settleType"]],
+            execution_type=ExecutionType[data["executionType"]],
+            side=OrderSide[data["side"]],
+            order_status=status,
+            cancel_type=CancelType[data.get("cancelType", CancelType.NONE.name)],
+            order_timestamp=timestamp,
+            price=int(data.get("price", data.get("orderPrice"))),
+            size=Decimal(data.get("size", data.get("orderSize"))),
+            executed_size=Decimal(
+                data.get("executedSize", data.get("orderExecutedSize"))
+            ),
+            losscut_price=int(data["losscutPrice"]),
+            time_in_force=data["timeInForce"],
+        )
+
+    @staticmethod
+    def to_positions(data: List[Item]) -> List["Position"]:
+        return [MessageHelper.to_position(x) for x in data]
+
+    @staticmethod
+    def to_position(data: Item) -> "Position":
+        return Position(
+            position_id=data["positionId"],
+            symbol=Symbol[data["symbol"]],
+            side=OrderSide[data["side"]],
+            size=Decimal(data["size"]),
+            orderd_size=Decimal(data["orderdSize"]),
+            price=int(data["price"]),
+            loss_gain=int(data["lossGain"]),
+            leverage=Decimal(data["leverage"]),
+            losscut_price=int(data["losscutPrice"]),
+            timestamp=parse_datetime(data.get("timestamp")),
+        )
+
+    @staticmethod
+    def to_position_summaries(data: List[Item]) -> List["PositionSummary"]:
+        return [MessageHelper.to_position_summary(x) for x in data]
+
+    @staticmethod
+    def to_position_summary(data: Item) -> "PositionSummary":
+        return PositionSummary(
+            symbol=Symbol[data["symbol"]],
+            side=OrderSide[data["side"]],
+            average_position_rate=int(data["averagePositionRate"]),
+            position_loss_gain=int(data["positionLossGain"]),
+            sum_order_quantity=Decimal(data["sumOrderQuantity"]),
+            sum_position_quantity=Decimal(data["sumPositionQuantity"]),
+            timestamp=parse_datetime(data.get("timestamp"))
+            if data.get("timestamp")
+            else datetime.now(timezone.utc),
+        )
+
+
+class GmoCoinDataStoreInterface(DataStoreInterface):
+    def _init(self) -> None:
+        self.create("orderbook", datastore_class=OrderBookStore)
+        self.create("orders", datastore_class=OrderStore)
+        self.create("positions", datastore_class=PositionStore)
+        self.create("executions", datastore_class=ExecutionStore)
+        self.create("position_summary", datastore_class=PositionSummaryStore)
+
+    async def initialize(self, *aws: Awaitable[aiohttp.ClientResponse]) -> None:
+        for f in asyncio.as_completed(aws):
+            resp = await f
+            data = await resp.json()
+            if (
+                resp.url.path == "/private/v1/latestExecutions"
+                and "list" in data["data"]
+            ):
+                self.executions._onresponse(
+                    MessageHelper.to_executions(data["data"]["list"])
+                )
+            if resp.url.path == "/private/v1/activeOrders" and "list" in data["data"]:
+                self.orders._onresponse(MessageHelper.to_orders(data["data"]["list"]))
+            if resp.url.path == "/private/v1/openPositions" and "list" in data["data"]:
+                self.positions._onresponse(
+                    MessageHelper.to_positions(data["data"]["list"])
+                )
+            if (
+                resp.url.path == "/private/v1/positionSummary"
+                and "list" in data["data"]
+            ):
+                self.position_summary._onresponse(
+                    MessageHelper.to_position_summaries(data["data"]["list"])
+                )
+
+    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:
+        if "channel" in msg:
+            msg_type = MessageType[msg.get("msgType", MessageType.NONE.name)]
+            channel: Channel = Channel.from_str(msg["channel"])
+            # Public
+            if channel == Channel.ORDER_BOOKS:
+                self.orderbook._onmessage(MessageHelper.to_orderbook(msg))
+            # Private
+            elif channel == Channel.EXECUTION_EVENTS:
+                asyncio.create_task(
+                    self.orders._onexecution(MessageHelper.to_execution(msg))
+                )
+                asyncio.create_task(
+                    self.executions._onmessage(MessageHelper.to_execution(msg))
+                )
+            elif channel == Channel.ORDER_EVENTS:
+                asyncio.create_task(self.orders._onmessage(MessageHelper.to_order(msg)))
+            elif channel == Channel.POSITION_EVENTS:
+                self.positions._onmessage(MessageHelper.to_position(msg), msg_type)
+            elif channel == Channel.POSITION_SUMMARY_EVENTS:
+                self.position_summary._onmessage(MessageHelper.to_position_summary(msg))
+
+    @property
+    def orderbook(self) -> OrderBookStore:
+        return self.get("orderbook", OrderBookStore)
+
+    @property
+    def orders(self) -> OrderStore:
+        return self.get("orders", OrderStore)
+
+    @property
+    def positions(self) -> PositionStore:
+        return self.get("positions", PositionStore)
+
+    @property
+    def executions(self) -> ExecutionStore:
+        return self.get("executions", ExecutionStore)
+
+    @property
+    def position_summary(self) -> PositionSummaryStore:
+        return self.get("position_summary", PositionSummaryStore)

--- a/pybotters/models/gmocoin.py
+++ b/pybotters/models/gmocoin.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum, auto
@@ -187,7 +186,6 @@ class CancelType(Enum):
     PRICE_LIMIT = auto()
 
 
-@dataclass
 class Ticker(TypedDict):
     ask: int
     bid: int
@@ -199,7 +197,6 @@ class Ticker(TypedDict):
     volume: Decimal
 
 
-@dataclass
 class OrderLevel(TypedDict):
     symbol: Symbol
     side: OrderSide
@@ -207,7 +204,6 @@ class OrderLevel(TypedDict):
     size: Decimal
 
 
-@dataclass
 class OrderBook(TypedDict):
     asks: List[OrderLevel]
     bids: List[OrderLevel]
@@ -215,7 +211,6 @@ class OrderBook(TypedDict):
     timestamp: datetime
 
 
-@dataclass
 class Trade(TypedDict):
     price: int
     side: OrderSide
@@ -224,7 +219,6 @@ class Trade(TypedDict):
     symbol: Symbol
 
 
-@dataclass
 class Execution(TypedDict):
     execution_id: int
     order_id: int
@@ -246,7 +240,6 @@ class Execution(TypedDict):
     time_in_force: Optional[str]
 
 
-@dataclass
 class Order(TypedDict):
     order_id: int
     symbol: Symbol
@@ -264,7 +257,6 @@ class Order(TypedDict):
     cancel_type: Optional[CancelType]
 
 
-@dataclass
 class Position(TypedDict):
     position_id: int
     symbol: Symbol
@@ -278,7 +270,6 @@ class Position(TypedDict):
     timestamp: datetime
 
 
-@dataclass
 class PositionSummary(TypedDict):
     symbol: Symbol
     side: OrderSide

--- a/pybotters/models/gmocoin.py
+++ b/pybotters/models/gmocoin.py
@@ -237,7 +237,7 @@ class Execution(TypedDict):
     timestamp: datetime
     loss_gain: int
     fee: int
-    # websocket only
+    # properties that only appears websocket message
     position_id: Optional[int]
     execution_type: Optional[ExecutionType]
     order_price: Optional[int]
@@ -261,7 +261,7 @@ class Order(TypedDict):
     executed_size: Decimal
     losscut_price: int
     time_in_force: TimeInForce
-    # websocket only
+    # properties that only appears websocket message
     cancel_type: Optional[CancelType]
 
 

--- a/pybotters/models/gmocoin.py
+++ b/pybotters/models/gmocoin.py
@@ -17,7 +17,6 @@ from typing import (
 import aiohttp
 from pybotters.store import DataStore, DataStoreInterface
 from pybotters.typedefs import Item
-from pybotters.ws import ClientWebSocketResponse
 
 logger = logging.getLogger(__name__)
 
@@ -574,7 +573,7 @@ class GmoCoinDataStoreInterface(DataStoreInterface):
                     MessageHelper.to_position_summaries(data["data"]["list"])
                 )
 
-    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:
+    def _onmessage(self, msg: Item) -> None:
         if "channel" in msg:
             msg_type = MessageType[msg.get("msgType", MessageType.NONE.name)]
             channel: Channel = Channel.from_str(msg["channel"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ homepage = "https://github.com/MtkN1/pybotters"
 python = "^3.7"
 aiohttp = "^3.7.4"
 rich = "^10.1.0"
+typing-extensions = "^3.10.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.3"


### PR DESCRIPTION
related: #60 

----

- Public WebSocket
  - [ ] [最新レート](https://api.coin.z.com/docs/#ws-ticker)
  - [x] [板情報](https://api.coin.z.com/docs/#ws-orderbooks)
  - [ ] [取引履歴](https://api.coin.z.com/docs/#ws-trades)
- Private WebSocket
  - [x] [約定](https://api.coin.z.com/docs/#ws-execution-events)
  - [x] [注文](https://api.coin.z.com/docs/#ws-order-events)
  - [x] [ポジション](https://api.coin.z.com/docs/#ws-position-events)
  - [x] [ポジションサマリー](https://api.coin.z.com/docs/#ws-position-summary-events)

----

- できるだけエディタの支援を効かせるため、積極的に型を書いています。
  - 値の一覧が既知のプロパティについては列挙型を定義しています。（[レファレンス > パラメータ](https://api.coin.z.com/docs/#parameters-ref) など）
  - 各データは `TypedDict` として実装してあります。独自クラスではなく `TypedDict` 型を採用した理由は、現状データストアが取り扱うデータの型が `Dict[str, Any]` である `Item` であるため、既存データストアの実装を変更せずに互換性を持たせられるためです。（データの出し入れ時に `Item` 型との `cast` をしています）
- GMO コインは REST API と WebSocket API で同じ種類のデータについても返却データの型が一致していないため、片方にしか存在しないプロパティは `Optional` 型になっています。