### PR TITLE
DataStore の wait メソッドが変更されたデータを返す実装

### DIFF
--- a/pybotters/store.py
+++ b/pybotters/store.py
@@ -158,7 +158,8 @@ class DataStore:
         self._events.append(event)
         await event.wait()
         try:
-            _, ret = self._events_return.popitem(event)
+            ret = self._events_return[event]
+            del self._events_return[event]
         except KeyError:
             ret = None
         return ret

--- a/pybotters/store.py
+++ b/pybotters/store.py
@@ -147,13 +147,13 @@ class DataStore:
         else:
             return list(self)
 
-    def _set(self, data=None) -> None:
+    def _set(self, data: List[Item] = None) -> None:
         for event in self._events:
             event.set()
             self._events_return[event] = data
         self._events.clear()
 
-    async def wait(self) -> None:
+    async def wait(self) -> List[Item]:
         event = asyncio.Event()
         self._events.append(event)
         await event.wait()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -222,20 +222,78 @@ def test_set():
 
 
 @pytest.mark.asyncio
-async def test_wait():
+async def test_wait_set():
     data = [{'dummy': 'data'}]
     ret = {}
 
     class DataStoreHasDummySet(pybotters.store.DataStore):
-        async def _set(self, data=None) -> None:
+        async def _set(self, data) -> None:
             return super()._set(data)
 
-    async def wait_func():
+    async def wait_func(ds):
         ret['val'] = await ds.wait()
 
-    ds = DataStoreHasDummySet()
-    t_wait = asyncio.create_task(wait_func())
-    t_set = asyncio.create_task(ds._set(data))
-    await asyncio.wait_for(t_wait, timeout=5.0)
-    assert t_set.done()
+    ds0 = DataStoreHasDummySet()
+    t_wait0 = asyncio.create_task(wait_func(ds0))
+    t_set0 = asyncio.create_task(ds0._set(data))
+    await asyncio.wait_for(t_wait0, timeout=5.0)
+    assert t_set0.done()
+    assert data == ret['val']
+
+
+@pytest.mark.asyncio
+async def test_wait_insert():
+    data = [{'dummy': 'data'}]
+    ret = {}
+
+    class DataStoreHasDummySet(pybotters.store.DataStore):
+        async def _insert(self, data) -> None:
+            return super()._insert(data)
+
+    async def wait_func(ds):
+        ret['val'] = await ds.wait()
+
+    ds1 = DataStoreHasDummySet()
+    t_wait1 = asyncio.create_task(wait_func(ds1))
+    t_set1 = asyncio.create_task(ds1._insert(data))
+    await asyncio.wait_for(t_wait1, timeout=5.0)
+    assert t_set1.done()
+    assert data == ret['val']
+
+
+async def test_wait_update():
+    data = [{'dummy': 'data'}]
+    ret = {}
+
+    class DataStoreHasDummySet(pybotters.store.DataStore):
+        async def _update(self, data) -> None:
+            return super()._update(data)
+
+    async def wait_func(ds):
+        ret['val'] = await ds.wait()
+
+    ds2 = DataStoreHasDummySet()
+    t_wait2 = asyncio.create_task(wait_func(ds2))
+    t_set2 = asyncio.create_task(ds2._update(data))
+    await asyncio.wait_for(t_wait2, timeout=5.0)
+    assert t_set2.done()
+    assert data == ret['val']
+
+
+async def test_wait_delete():
+    data = [{'dummy': 'data'}]
+    ret = {}
+
+    class DataStoreHasDummySet(pybotters.store.DataStore):
+        async def _delete(self, data) -> None:
+            return super()._delete(data)
+
+    async def wait_func(ds):
+        ret['val'] = await ds.wait()
+
+    ds3 = DataStoreHasDummySet()
+    t_wait3 = asyncio.create_task(wait_func(ds3))
+    t_set3 = asyncio.create_task(ds3._delete(data))
+    await asyncio.wait_for(t_wait3, timeout=5.0)
+    assert t_set3.done()
     assert data == ret['val']

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -261,6 +261,7 @@ async def test_wait_insert():
     assert data == ret['val']
 
 
+@pytest.mark.asyncio
 async def test_wait_update():
     data = [{'dummy': 'data'}]
     ret = {}
@@ -280,6 +281,7 @@ async def test_wait_update():
     assert data == ret['val']
 
 
+@pytest.mark.asyncio
 async def test_wait_delete():
     data = [{'dummy': 'data'}]
     ret = {}

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -246,14 +246,14 @@ async def test_wait_insert():
     data = [{'dummy': 'data'}]
     ret = {}
 
-    class DataStoreHasDummySet(pybotters.store.DataStore):
+    class DataStoreHasDummyInsert(pybotters.store.DataStore):
         async def _insert(self, data) -> None:
             return super()._insert(data)
 
     async def wait_func(ds):
         ret['val'] = await ds.wait()
 
-    ds1 = DataStoreHasDummySet()
+    ds1 = DataStoreHasDummyInsert()
     t_wait1 = asyncio.create_task(wait_func(ds1))
     t_set1 = asyncio.create_task(ds1._insert(data))
     await asyncio.wait_for(t_wait1, timeout=5.0)
@@ -266,14 +266,14 @@ async def test_wait_update():
     data = [{'dummy': 'data'}]
     ret = {}
 
-    class DataStoreHasDummySet(pybotters.store.DataStore):
+    class DataStoreHasDummyUpdate(pybotters.store.DataStore):
         async def _update(self, data) -> None:
             return super()._update(data)
 
     async def wait_func(ds):
         ret['val'] = await ds.wait()
 
-    ds2 = DataStoreHasDummySet()
+    ds2 = DataStoreHasDummyUpdate()
     t_wait2 = asyncio.create_task(wait_func(ds2))
     t_set2 = asyncio.create_task(ds2._update(data))
     await asyncio.wait_for(t_wait2, timeout=5.0)
@@ -286,14 +286,14 @@ async def test_wait_delete():
     data = [{'dummy': 'data'}]
     ret = {}
 
-    class DataStoreHasDummySet(pybotters.store.DataStore):
+    class DataStoreHasDummyDelete(pybotters.store.DataStore):
         async def _delete(self, data) -> None:
             return super()._delete(data)
 
     async def wait_func(ds):
         ret['val'] = await ds.wait()
 
-    ds3 = DataStoreHasDummySet()
+    ds3 = DataStoreHasDummyDelete()
     t_wait3 = asyncio.create_task(wait_func(ds3))
     t_set3 = asyncio.create_task(ds3._delete(data))
     await asyncio.wait_for(t_wait3, timeout=5.0)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -214,9 +214,11 @@ def test_set():
     ds = pybotters.store.DataStore()
     events = [asyncio.Event(), asyncio.Event(), asyncio.Event()]
     ds._events.extend(events)
-    ds._set()
+    data = [{'dummy': 'data'}]
+    ds._set(data)
     assert all(e.is_set() for e in events)
     assert not len(ds._events)
+    assert all(ds._events_return[e] == data for e in events)
 
 
 @pytest.mark.asyncio

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -212,13 +212,12 @@ def test__iter__():
 
 def test_set():
     ds = pybotters.store.DataStore()
-    events = [asyncio.Event(), asyncio.Event(), asyncio.Event()]
-    ds._events.extend(events)
-    data = [{'dummy': 'data'}]
+    event = asyncio.Event()
+    ds._events[event] = []
+    data = [{'dummy1': 'data1'}, {'dummy2': 'data2'}, {'dummy3': 'data3'}]
     ds._set(data)
-    assert all(e.is_set() for e in events)
-    assert not len(ds._events)
-    assert all(ds._events_return[e] == data for e in events)
+    assert all(e.is_set() for e in ds._events)
+    assert ds._events[event] == data
 
 
 @pytest.mark.asyncio

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -223,12 +223,19 @@ def test_set():
 
 @pytest.mark.asyncio
 async def test_wait():
+    data = [{'dummy': 'data'}]
+    ret = {}
+
     class DataStoreHasDummySet(pybotters.store.DataStore):
-        async def _set(self) -> None:
-            return super()._set()
+        async def _set(self, data=None) -> None:
+            return super()._set(data)
+
+    async def wait_func():
+        ret['val'] = await ds.wait()
 
     ds = DataStoreHasDummySet()
-    t_wait = asyncio.create_task(ds.wait())
-    t_set = asyncio.create_task(ds._set())
+    t_wait = asyncio.create_task(wait_func())
+    t_set = asyncio.create_task(ds._set(data))
     await asyncio.wait_for(t_wait, timeout=5.0)
     assert t_set.done()
+    assert data == ret['val']


### PR DESCRIPTION
#75 の storewait() が変更されたデータを返す場合の簡単な実装です。
以下のメソッドの引数 data に渡された値を store.wait() が返します。

- _insert
- _update
- _delete

実際に変更されたデータが返されるわけではないことに注意してください。

get や find のようなクエリによる絞り込み機能は実装していません。