### PR TITLE
BybitのKlineのinitializeを追加する

### DIFF
--- a/pybotters/models/bybit.py
+++ b/pybotters/models/bybit.py
@@ -51,7 +51,7 @@ class BybitDataStore(DataStoreManager):
                 self.position_usdt._onresponse(data['result'])
             elif resp.url.path in ('/v2/private/wallet/balance',):
                 self.wallet._onresponse(data['result'])
-            elif resp.url.path in ("/v2/public/kline/list",):
+            elif resp.url.path in ("/v2/public/kline/list", "/public/linear/kline"):
                 self.kline._onresponse(data["result"])
 
     def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:

--- a/pybotters/models/bybit.py
+++ b/pybotters/models/bybit.py
@@ -51,6 +51,8 @@ class BybitDataStore(DataStoreManager):
                 self.position_usdt._onresponse(data['result'])
             elif resp.url.path in ('/v2/private/wallet/balance',):
                 self.wallet._onresponse(data['result'])
+            elif resp.url.path in ("/v2/public/kline/list",):
+                self.kline._onresponse(data["result"])
 
     def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:
         if 'success' in msg:
@@ -204,6 +206,27 @@ class Kline(DataStore):
             item['symbol'] = topic_split[-1]
             item['period'] = topic_split[-2]
         self._update(data)
+
+    def _onresponse(self, data: List[Item]) -> None:
+        ws_format_data = [
+            {
+                "start": kline["open_time"],
+                "end": None,
+                "open": float(kline["open"]),
+                "close": float(kline["close"]),
+                "high": float(kline["high"]),
+                "low": float(kline["low"]),
+                "volume": float(kline["volume"]),
+                "turnover": float(kline["turnover"]),
+                "confirm": None,
+                "cross_seq": None,
+                "timestamp": None,
+                "period": kline["interval"],
+                "symbol": kline["symbol"],
+            }
+            for kline in data
+        ]
+        self._update(ws_format_data)
 
 
 class PositionInverse(DataStore):

--- a/pybotters/models/bybit.py
+++ b/pybotters/models/bybit.py
@@ -208,25 +208,18 @@ class Kline(DataStore):
         self._update(data)
 
     def _onresponse(self, data: List[Item]) -> None:
-        ws_format_data = [
-            {
-                "start": kline["open_time"],
-                "end": None,
-                "open": float(kline["open"]),
-                "close": float(kline["close"]),
-                "high": float(kline["high"]),
-                "low": float(kline["low"]),
-                "volume": float(kline["volume"]),
-                "turnover": float(kline["turnover"]),
-                "confirm": None,
-                "cross_seq": None,
-                "timestamp": None,
-                "period": kline["interval"],
-                "symbol": kline["symbol"],
-            }
-            for kline in data
-        ]
-        self._update(ws_format_data)
+        for item in data:
+            item["start"] = item.pop("open_time")
+            item["period"] = item.pop("interval")
+            for k in ['open', 'high', 'low', 'close']:
+                item[k] = float(item[k])
+            if 'id' in item.keys():
+                item['volume'] = str(item['volume'])
+                item['turnover'] = str(item['turnover'])
+            else:
+                item['volume'] = int(item['volume'])
+                item['turnover'] = float(item['turnover'])
+        self._update(data)
 
 
 class PositionInverse(DataStore):


### PR DESCRIPTION
#28 についてKlineでもInitializeできるようにしてみました。

restからwsへの変換を
```
{
"start": kline["open_time"],
"end": None,
"open": float(kline["open"]),
"close": float(kline["close"]),
"high": float(kline["high"]),
"low": float(kline["low"]),
"volume": float(kline["volume"]),
"turnover": float(kline["turnover"]),
"confirm": None,
"cross_seq": None,
"timestamp": None,
"period": kline["interval"],
"symbol": kline["symbol"],
}
```
としたのですが、
懸念点が二つあります。
1. volumeの型をinverse, linear問わずfloatにしている。本来inverseではint、linearでは
2. periodが、restでは"720"があるのに対して、wsではそれがない。

確認のほどよろしくお願いします。