### PR TITLE
bitbankDataStoreのDepthにtimestampを追加

### DIFF
--- a/pybotters/models/bitbank.py
+++ b/pybotters/models/bitbank.py
@@ -53,6 +53,9 @@ class Depth(DataStore):
     _KEYS = ['pair', 'side', 'price']
     _BDSIDE = {'sell': 'asks', 'buy': 'bids'}
 
+    def _init(self) -> None:
+        self.timestamp: Optional[int] = None
+
     def sorted(self, query: Optional[Item] = None) -> dict[str, list[list[str]]]:
         if query is None:
             query = {}
@@ -70,9 +73,11 @@ class Depth(DataStore):
             result = self.find({'pair': pair})
             self._delete(result)
             tuples = (('bids', 'buy'), ('asks', 'sell'))
+            self.timestamp = data["timestamp"]
         else:
             pair = room_name.replace('depth_diff_', '')
             tuples = (('b', 'buy'), ('a', 'sell'))
+            self.timestamp = data["t"]
 
         for boardside, side in tuples:
             for item in data[boardside]:


### PR DESCRIPTION
bitbankDataStoreのDepthにtimestampを追加しました。
#88 と同様に_onmessage()でself.timestampを更新する実装です。

- 動作確認用コード
bitbankの板取得用のチャンネルはdepth_whole_*, depth_diff_*の2つがあります（[公式ドキュメント](https://github.com/bitbankinc/bitbank-api-docs/blob/master/public-stream.md#depth-diff)）。
今回はdepth_wholeのみ/depth_diffのみ/両方Subscribeの3パターンで動作確認を行い、いずれもtimestampが格納できていることを確認しました。
```
import asyncio
from tmp.pybotters import pybotters


async def main():
    async with pybotters.Client() as client:
        store = pybotters.bitbankDataStore()
        wstask = await client.ws_connect(
            'wss://stream.bitbank.cc/socket.io/?EIO=3&transport=websocket',
            send_str=[
                '42["join-room","depth_whole_btc_jpy"]',  # 適宜コメントアウト
                '42["join-room","depth_diff_btc_jpy"]'  # 適宜コメントアウト
            ],
            hdlr_str=store.onmessage,
        )
        while True:
            await store.depth.wait()
            print(store.depth.timestamp)  # timestampを出力


if __name__ == '__main__':
    asyncio.run(main())
```

- 出力
DataStoreにタイムスタンプが格納されていることを確認
```
1646243716289
1646243716640
1646243716587
1646243716985
...
```