### PR TITLE
bitFlyerのポジションがずれる問題の対応

### DIFF
--- a/pybotters/models/bitflyer.py
+++ b/pybotters/models/bitflyer.py
@@ -260,11 +260,13 @@ class Positions(DataStore):
                                     item["size"], int
                                 ):
                                     pos["size"] -= item["size"]
+                                    item["size"] = 0
                                 else:
                                     pos["size"] = float(
                                         Decimal(str(pos["size"]))
                                         - Decimal(str(item["size"]))
                                     )
+                                    item["size"] = 0.0
                                 break
                             else:
                                 if isinstance(pos["size"], int) and isinstance(
@@ -277,8 +279,8 @@ class Positions(DataStore):
                                         - Decimal(str(pos["size"]))
                                     )
                                 self._remove([uid])
-                                if not pos["size"]:
-                                    break
+                        if item["size"] > 0:
+                            self._insert([self._common_keys(item)])
                 else:
                     try:
                         self._insert([self._common_keys(item)])


### PR DESCRIPTION
# 現状

- ポジション 0の状態
- 0.01購入 -> ポジション 0.01
- 0.02売却 -> ポジション 0 

0.02売却した場合にポジションが-0.01になってほしいが、0になっている

再現コード
```python
import pybotters
import asyncio
from decimal import Decimal


def get_total_position_size(store: pybotters.bitFlyerDataStore) -> Decimal:
    amount = Decimal(0)
    for position in store.positions:
        if position["side"] == "SELL":
            amount -= Decimal(str(position["size"]))
        if position["side"] == "BUY":
            amount += Decimal(str(position["size"]))
    return amount


async def main():
    key = ...
    secret = ...
    base_url = "https://api.bitflyer.com"
    apis = {"bitflyer": [key, secret]}
    async with pybotters.Client(base_url=base_url, apis=apis) as client:
        store = pybotters.bitFlyerDataStore()
        await store.initialize(
            client.get("/v1/me/getpositions?product_code=FX_BTC_JPY"),
        )

        await client.ws_connect(
            "wss://ws.lightstream.bitflyer.com/json-rpc",
            send_json=[
                {"method": "subscribe", "params": {"channel": "child_order_events"}, "id": 4},
                {"method": "subscribe", "params": {"channel": "parent_order_events"}, "id": 5},
            ],
            hdlr_json=store.onmessage,
            heartbeat=10.0,
        )

        await asyncio.sleep(5)
        print("total position size", get_total_position_size(store))

        print("buy 0.01")
        await client.post(
            "/v1/me/sendchildorder",
            data={
                "product_code": "FX_BTC_JPY",
                "child_order_type": "MARKET",
                "side": "BUY",
                "size": "0.01",
            }
        )

        await asyncio.sleep(1)
        print("total position size", get_total_position_size(store))

        print("sell 0.02")
        await client.post(
            "/v1/me/sendchildorder",
            data={
                "product_code": "FX_BTC_JPY",
                "child_order_type": "MARKET",
                "side": "SELL",
                "size": "0.02",
            }
        )

        await asyncio.sleep(1)
        print("total position size", get_total_position_size(store))

if __name__ == '__main__':
    try:
        asyncio.run(main())
    except KeyboardInterrupt:
        pass

# total position size 0
# buy 0.01
# total position size 0.01
# sell 0.02
# total position size 0
```

# 原因

現在のポジションと逆になるポジションになるような約定イベントが来た場合に、逆ポジションの量が保存されない

# 関連するissue

https://github.com/MtkN1/pybotters/issues/103

# その他

頻繁に逆ポジションになるbot（1分間に1回程度）を動かして半日程度ポジションがずれないことは確認しました。
念の為、他の方にもポジションにズレが出ないか検証お願いしたいです。