### PR TITLE
bitFlyerのDataStoreでポジションを初期化するたびに増える問題の対応

### DIFF
--- a/pybotters/models/bitflyer.py
+++ b/pybotters/models/bitflyer.py
@@ -242,7 +242,9 @@ class Positions(DataStore):
 
     def _onresponse(self, data: list[Item]) -> None:
         if data:
-            self._delete(self.find({"product_code": data[0]["product_code"]}))
+            positions = self._find_with_uuid({"product_code": data[0]["product_code"]})
+            if positions:
+                self._remove(list(positions.keys()))
             for item in data:
                 self._insert([self._common_keys(item)])
 


### PR DESCRIPTION
# 現状

`bitFlyerDataStore.initialize()`でポジションを初期化するたびに、ポジションが増える

再現コード
```python
import pybotters
import asyncio


def print_positions(store: pybotters.bitFlyerDataStore):
    print(f"=== positions({len(store.positions)}) ===")
    for position in store.positions:
        print(position)


async def main():
    key = ...
    secret = ...
    base_url = "https://api.bitflyer.com"
    apis = {"bitflyer": [key, secret]}
    async with pybotters.Client(base_url=base_url, apis=apis) as client:
        store = pybotters.bitFlyerDataStore()
        await store.initialize(
            client.get("/v1/me/getpositions?product_code=FX_BTC_JPY"),
        )

        print_positions(store)

        await client.post(
            "/v1/me/sendchildorder",
            data={
                "product_code": "FX_BTC_JPY",
                "child_order_type": "MARKET",
                "side": "BUY",
                "size": "0.01",
            }
        )

        await asyncio.sleep(1)
        await store.initialize(
            client.get("/v1/me/getpositions?product_code=FX_BTC_JPY"),
        )
        print_positions(store)

        await asyncio.sleep(1)
        await store.initialize(
            client.get("/v1/me/getpositions?product_code=FX_BTC_JPY"),
        )
        print_positions(store)


if __name__ == '__main__':
    try:
        asyncio.run(main())
    except KeyboardInterrupt:
        pass

# === positions(0) ===
# === positions(1) ===
# {'product_code': 'FX_BTC_JPY', 'side': 'BUY', 'price': 3917279.0, 'size': 0.01, 'commission': 0.0, 'sfd': 0.0}
# === positions(2) ===
# {'product_code': 'FX_BTC_JPY', 'side': 'BUY', 'price': 3917279.0, 'size': 0.01, 'commission': 0.0, 'sfd': 0.0}
# {'product_code': 'FX_BTC_JPY', 'side': 'BUY', 'price': 3917279.0, 'size': 0.01, 'commission': 0.0, 'sfd': 0.0}
```

# 原因

_onresponseの処理の中でポジション初期化がうまく動いていなかった。
（`DataStore`クラスに`_KEYS`という定数がない場合`_delete()`が期待した動きにならなかった）
https://github.com/MtkN1/pybotters/blob/main/pybotters/models/bitflyer.py#L245

# 解決方法

bitFlyerの`Position`クラスのポジション削除方法と同様に`_remove()`でポジションを削除する。
