### PR TITLE
watch メソッドの変更クラスに影響されたストアとデータを追加する

### DIFF
--- a/pybotters/store.py
+++ b/pybotters/store.py
@@ -74,10 +74,10 @@ class DataStore:
                         _id = uuid.uuid4()
                         self._data[_id] = item
                         self._index[keyhash] = _id
-                        self._put("insert", item, item)
+                        self._put("insert", None, item)
                     else:
                         self._data[self._index[keyhash]] = item
-                        self._put("insert", item, item)
+                        self._put("insert", None, item)
             self._sweep_with_key()
         else:
             for item in data:
@@ -85,7 +85,7 @@ class DataStore:
                     self._cast_item(item)
                 _id = uuid.uuid4()
                 self._data[_id] = item
-                self._put("insert", item, item)
+                self._put("insert", None, item)
             self._sweep_without_key()
         # !TODO! This behaviour might be undesirable.
         self._set(data)
@@ -108,7 +108,7 @@ class DataStore:
                         _id = uuid.uuid4()
                         self._data[_id] = item
                         self._index[keyhash] = _id
-                        self._put("update", item, item)
+                        self._put("update", None, item)
             self._sweep_with_key()
         else:
             for item in data:
@@ -116,7 +116,7 @@ class DataStore:
                     self._cast_item(item)
                 _id = uuid.uuid4()
                 self._data[_id] = item
-                self._put("update", item, item)
+                self._put("update", None, item)
             self._sweep_without_key()
         # !TODO! This behaviour might be undesirable.
         self._set(data)


### PR DESCRIPTION
## Description

ストアの watch メソッドで取得される変更クラス ***StoreChange*** において、影響された元の情報を参照できるよう影響元ストア及びソースデータのプロパティを追加した。

## Example

bitFlyer でのオーダーキャンセルした場合の変更クラス例

### 変更前

```py
StoreChange(
│   operation='delete',
│   data={
│   │   'product_code': 'BTC_JPY',
│   │   'child_order_id': 'JOR20221228-121846-331601',
│   │   'child_order_acceptance_id': 'JRF20221228-121846-183970',
│   │   'event_date': '2022-12-28T12:18:46.9290446Z',
│   │   'event_type': 'ORDER',
│   │   'child_order_type': 'LIMIT',
│   │   'side': 'BUY',
│   │   'price': 2228600,
│   │   'size': 0.001,
│   │   'expire_date': '2023-01-27T12:18:46'
│   }
)
```

### 変更後

```py
StoreChange(
│   store=<pybotters.models.bitflyer.ChildOrders object at 0x7fe8b38efcd0>,
│   operation='delete',
│   source={
│   │   'product_code': 'BTC_JPY',
│   │   'child_order_id': 'JOR20221228-121846-331601',
│   │   'child_order_acceptance_id': 'JRF20221228-121846-183970',
│   │   'event_date': '2022-12-28T12:18:48.8355776Z',
│   │   'event_type': 'CANCEL',
│   │   'price': 2228600,
│   │   'size': 0.001
│   },
│   data={
│   │   'product_code': 'BTC_JPY',
│   │   'child_order_id': 'JOR20221228-121846-331601',
│   │   'child_order_acceptance_id': 'JRF20221228-121846-183970',
│   │   'event_date': '2022-12-28T12:18:46.9290446Z',
│   │   'event_type': 'ORDER',
│   │   'child_order_type': 'LIMIT',
│   │   'side': 'BUY',
│   │   'price': 2228600,
│   │   'size': 0.001,
│   │   'expire_date': '2023-01-27T12:18:46'
│   }
)
```

### ***source*** プロパティ

元々の実装より *data* プロパティは「ストア内部データとして CRUD が発生したアイテム」を格納している。 上の例では「削除されたオーダーのアイテム」を表している。 しかし「何によって削除されたか」が参照できなかった。 ***source*** プロパティにより影響を受けたアイテムを参照できるようになった。

***source*** プロパティ は「更新元のアイテムがあり上書きされた」*update* オペレーションと「影響元が特定される」*delete* オペレーションの際に影響元のアイテムが格納される。 *insert* オペレーション、「更新元のアイテムがなく新規挿入された」*update* オペレーション、「影響元が特定できない (一括削除など)」*delete* オペレーションでは *None* が格納される。

### ***store*** プロパティ

影響元の DataStore が格納される。