### PR TITLE
ストアにおけるアイテムの参照性を変更する

### DIFF
--- a/pybotters/models/kucoin.py
+++ b/pybotters/models/kucoin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 import time
 from typing import Any, Awaitable, Optional
@@ -111,8 +112,8 @@ class KuCoinDataStore(DataStoreManager):
                 self.markprice._onmessage(msg)
 
             elif topic.endswith("tradeOrders") or topic.endswith("advancedOrders"):
-                self.orderevents._onmessage(msg)
-                self.orders._onmessage(msg)
+                self.orderevents._onmessage(copy.deepcopy(msg))
+                self.orders._onmessage(copy.deepcopy(msg))
 
             elif topic.startswith("/contract/instrument"):
                 self.instrument._onmessage(msg)
@@ -130,12 +131,12 @@ class KuCoinDataStore(DataStoreManager):
                 self.marginfundingbook._onmessage(msg)
 
             elif topic.startswith("/margin/position"):
-                self.marginpositions._onmessage(msg)
-                self.marginpositionevents._onmessage(msg)
+                self.marginpositions._onmessage(copy.deepcopy(msg))
+                self.marginpositionevents._onmessage(copy.deepcopy(msg))
 
             elif topic.startswith("/margin/loan"):
-                self.marginorders._onmessage(msg)
-                self.marginorderevents._onmessage(msg)
+                self.marginorders._onmessage(copy.deepcopy(msg))
+                self.marginorderevents._onmessage(copy.deepcopy(msg))
 
             elif topic.startswith("/contractAccount/wallet"):
                 self.balanceevents._onmessage(msg)

--- a/pybotters/store.py
+++ b/pybotters/store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import uuid
 from dataclasses import dataclass
 from typing import Any, Hashable, Iterator, Optional, Type, TypeVar, cast
@@ -260,7 +261,9 @@ class DataStore:
 
     def _put(self, operation: str, source: Optional[Item], item: Item) -> None:
         for queue in self._queues:
-            queue.put_nowait(StoreChange(self, operation, source, item))
+            queue.put_nowait(
+                StoreChange(self, operation, copy.deepcopy(source), copy.deepcopy(item))
+            )
 
     def watch(self) -> "StoreStream":
         return StoreStream(self)


### PR DESCRIPTION
Resolve: Individual PR and #180

ストアにおけるアイテムの参照性の変更を行う。

- *StoreChagne* クラスのプロパティ ***source*** と ***data*** はコピーされたアイテムを格納する

例えばオーダーに関する 2 件のメッセージを同期的に受信し、Insert -> size: 0 に Update という操作が行われた場合、watch で受信する側では insert オペレーションのアイテム受信時点で update が行われたアイテムを参照するので size: 0 の状態になっていた。 コピーしたアイテムを *StoreChagne* クラスに格納することでこの問題が解決される。

- *DataStoreManager* 継承クラスらの *_onmessage* における *DataStore* へのメッセージの受け渡しで、1 つのメッセージを複数のストアに渡す場合コピーを行うようにする
  - bitFlyer の *child_order_events* チャンネルを元にデータを構成するストア
  - KuCoin の */margin/position*, */margin/loan* チャンネルを元にデータを構成するストア

1 つのストアでアイテムを編集した場合他のストアに影響が及ぶのが解決される。 bitFlyer の場合 #180。