### PR TITLE
bitFlyer Positions ストアでのアップデートの watch ストリームを有効にする

### DIFF
--- a/pybotters/models/bitflyer.py
+++ b/pybotters/models/bitflyer.py
@@ -294,6 +294,11 @@ class Positions(DataStore):
                                         - Decimal(str(item["size"]))
                                     )
                                     item["size"] = 0.0
+                                self._put(
+                                    operation="update",
+                                    source=item,
+                                    item=pos,
+                                )  # !NOTE! This is manual call to `_put` method.
                                 break
                             else:
                                 if isinstance(pos["size"], int) and isinstance(


### PR DESCRIPTION
bitFlyer の *Positions* ストアでは建玉のアップデート時、建玉アイテムのユニークキーがない為にアイテムの値を直接書き換えていたので *watch* メソッドによる変更ストリームが取得されなかったが、変更ストリームに通知する *_put* メソッドを直接呼び出すことによって更新が取得されるようになる。

例:
建玉が `[{"side": "BUY", "size": 0.02}]` の時に `{"side": "SELL", "size": 0.01}` の約定があると `[{"side": "BUY", "size": 0.01}]` に書き換えられる。 その際 watch で変更を取得できなかったが、`operation="update"` で取得できるようになる。