### PR TITLE
Workaround: Bybit の Derivatives v3 Contract API に対応する

### DIFF
--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -238,6 +238,37 @@ class Heartbeat:
 
 class Auth:
     @staticmethod
+    async def bybit(ws: aiohttp.ClientWebSocketResponse):
+        key: str = ws._response._session.__dict__["_apis"][
+            AuthHosts.items[ws._response.url.host].name
+        ][0]
+        secret: bytes = ws._response._session.__dict__["_apis"][
+            AuthHosts.items[ws._response.url.host].name
+        ][1]
+
+        expires = int((time.time() + 5.0) * 1000)
+        path = f"GET/realtime{expires}"
+        signature = hmac.new(
+            secret, path.encode(), digestmod=hashlib.sha256
+        ).hexdigest()
+
+        await ws.send_json(
+            {"op": "auth", "args": [key, expires, signature]},
+            _itself=True,
+        )
+        async for msg in ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                data = msg.json()
+                if "success" in data:
+                    if data["success"] is False:
+                        logger.warning(data)
+                if "op" in data:
+                    if data["op"] == "auth":
+                        break
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                break
+
+    @staticmethod
     async def bitflyer(ws: aiohttp.ClientWebSocketResponse):
         key: str = ws._response._session.__dict__["_apis"][
             AuthHosts.items[ws._response.url.host].name
@@ -444,6 +475,9 @@ class HeartbeatHosts:
 
 class AuthHosts:
     items = {
+        "stream.bybit.com": Item("bybit", Auth.bybit),
+        "stream.bytick.com": Item("bybit", Auth.bybit),
+        "stream-testnet.bybit.com": Item("bybit_testnet", Auth.bybit),
         "ws.lightstream.bitflyer.com": Item("bitflyer", Auth.bitflyer),
         "phemex.com": Item("phemex", Auth.phemex),
         "testnet.phemex.com": Item("phemex_testnet", Auth.phemex),

--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -239,6 +239,9 @@ class Heartbeat:
 class Auth:
     @staticmethod
     async def bybit(ws: aiohttp.ClientWebSocketResponse):
+        if not ws._response.url.path.startswith("/contract/private/v3"):
+            return
+
         key: str = ws._response._session.__dict__["_apis"][
             AuthHosts.items[ws._response.url.host].name
         ][0]


### PR DESCRIPTION
#184 の修正
* WebSocketでBybitのprivate channelの認証が通るようにしました
  * 手元のDerivatives V3 Contract API Testnetで動作を確認しました
* 合わせてtest_ws.pyにBybit用のテストケースを追加しました
* REST APIでの認証については現状のままでもDerivatives V3 Contract APIでは問題なく動作しているため、変更を加えていません

---

_[Author edited]_

## Bybit Derivatives v3 Contract API の対応

Derivatives v3 Contract API [^1] の認証が有効になるよう認証ロジックを追加した。

REST API は従来の認証ロジックで認証可能だったが、WebSocket は新たに認証メッセージの送信が必要であるためその実装を追加している。

Derivatives v3 Unifired Margin API [^2] の REST / WebSocket 認証については別途検証及び対応が必要であるため今回の PR では実装しない。

```py
# request code
async def main():
    async with pybotters.Client() as client:
        ws = await client.ws_connect(
            "wss://stream.bybit.com/contract/private/v3",
            send_json={
                "op": "subscribe",
                "req_id": "10110001",
                "args": ["user.wallet.contractAccount"],
            },
        )
        await ws

# output
{'req_id': '10110001', 'success': True, 'ret_msg': '', 'op': 'subscribe', 'conn_id': 'cev1kaj49coq5truuq70-1u13'}
```

[^1]: https://bybit-exchange.github.io/docs/derivativesV3/contract
[^2]: https://bybit-exchange.github.io/docs/derivativesV3/unified_margin