### PR TITLE
Bybit V5 API DataStore

### DIFF
--- a/pybotters/__init__.py
+++ b/pybotters/__init__.py
@@ -19,6 +19,7 @@ from .models.bitbank import bitbankDataStore
 from .models.bitflyer import bitFlyerDataStore
 from .models.bitget import BitgetDataStore
 from .models.bitmex import BitMEXDataStore
+from .models.bybit_v5 import BybitV5DataStore
 from .models.bybit import BybitInverseDataStore, BybitUSDTDataStore
 from .models.coincheck import CoincheckDataStore
 from .models.deprecated.binance import BinanceDataStore
@@ -39,6 +40,7 @@ __all__: Tuple[str, ...] = (
     "delete",
     "BybitDataStore",
     "CoincheckDataStore",
+    "BybitV5DataStore",
     "BybitInverseDataStore",
     "BybitUSDTDataStore",
     "BinanceDataStore",

--- a/pybotters/models/bybit_v5.py
+++ b/pybotters/models/bybit_v5.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Optional
+
+import aiohttp
+
+from ..store import DataStore, DataStoreManager
+from ..typedefs import Item
+from ..ws import ClientWebSocketResponse
+
+logger = logging.getLogger(__name__)
+
+
+class BybitV5DataStore(DataStoreManager):
+    def _init(self) -> None:
+        self.create("orderbook", datastore_class=OrderBook)
+        self.create("publicTrade", datastore_class=Trade)
+        self.create("tickers", datastore_class=Ticker)
+        self.create("kline", datastore_class=Kline)
+        self.create("liquidation", datastore_class=Liquidation)
+        self.create("kline_lt", datastore_class=LTKline)
+        self.create("tickers_lt", datastore_class=LTTicker)
+        self.create("lt", datastore_class=LTNav)
+        self.create("position", datastore_class=Position)
+        self.create("execution", datastore_class=Execution)
+        self.create("order", datastore_class=Order)
+        self.create("wallet", datastore_class=Wallet)
+        self.create("greek", datastore_class=Greek)
+
+    async def initialize(self, *aws: Awaitable[aiohttp.ClientResponse]) -> None:
+        """
+        対応エンドポイント
+
+        - GET /v2/private/order (DataStore: order)
+        """
+        for f in asyncio.as_completed(aws):
+            resp = await f
+            data = await resp.json()
+            if data["ret_code"] != 0:
+                raise ValueError(
+                    "Response error at DataStore initialization\n"
+                    f"URL: {resp.url}\n"
+                    f"Data: {data}"
+                )
+            if resp.url.path in (
+                "/v2/private/order",
+                "/futures/private/order",
+            ):
+                self.order._onresponse(data["result"])
+
+    def _onmessage(self, msg: Item, ws: ClientWebSocketResponse) -> None:
+        if "success" in msg:
+            if not msg["success"]:
+                logger.warning(msg)
+
+        if "topic" in msg:
+            dot_topic: str = msg["topic"]
+            topic, *topic_ext = dot_topic.split(".")
+
+            if topic in self:
+                getattr(self[topic], "_onmessage")(msg, topic_ext)
+
+    @property
+    def orderbook(self) -> "OrderBook":
+        return self.get("orderbook", OrderBook)
+
+    @property
+    def trade(self) -> "Trade":
+        return self.get("publicTrade", Trade)
+
+    @property
+    def ticker(self) -> "Ticker":
+        return self.get("tickers", Ticker)
+
+    @property
+    def kline(self) -> "Kline":
+        return self.get("kline", Kline)
+
+    @property
+    def liquidation(self) -> "Liquidation":
+        return self.get("liquidation", Liquidation)
+
+    @property
+    def lt_kline(self) -> "LTKline":
+        return self.get("kline_lt", LTKline)
+
+    @property
+    def lt_ticker(self) -> "LTTicker":
+        return self.get("tickers_lt", LTTicker)
+
+    @property
+    def lt_nav(self) -> "LTNav":
+        return self.get("lt", LTNav)
+
+    @property
+    def position(self) -> "Position":
+        return self.get("position", Position)
+
+    @property
+    def execution(self) -> "Execution":
+        return self.get("execution", Execution)
+
+    @property
+    def order(self) -> "Order":
+        return self.get("order", Order)
+
+    @property
+    def wallet(self) -> "Wallet":
+        return self.get("wallet", Wallet)
+
+    @property
+    def greek(self) -> "Greek":
+        return self.get("greek", Greek)
+
+
+class OrderBook(DataStore):
+    _KEYS = ["symbol", "side", "price"]
+
+    def sorted(self, query: Optional[Item] = None) -> dict[str, list[Item]]:
+        if query is None:
+            query = {}
+        result = {"asks": [], "bids": []}
+        for item in self:
+            if all(k in item and query[k] == item[k] for k in query):
+                result[item["side"]].append(item)
+        result["asks"].sort(key=lambda x: x["price"])
+        result["bids"].sort(key=lambda x: x["price"], reverse=True)
+        return result
+
+    def _onmessage(self, msg: Item, topic_ext: list[str]) -> None:
+        operation = {"delete": [], "update": [], "insert": []}
+
+        is_snapshot = msg["type"] == "snapshot"
+        if is_snapshot:
+            operation["delete"].extend(self.find({"symbol": msg["data"]["s"]}))
+
+        for side_k, side_v in (("a", "asks"), ("b", "bids")):
+            for item in msg["data"][side_k]:
+                dsitem = {
+                    "symbol": msg["data"]["s"],
+                    "side": side_v,
+                    "price": item[0],
+                    "size": item[1],
+                }
+                if is_snapshot:
+                    operation["insert"].append(dsitem)
+                elif dsitem["size"] == "0":
+                    operation["delete"].append(dsitem)
+                else:
+                    operation["update"].append(dsitem)
+
+        self._delete(operation["delete"])
+        self._update(operation["update"])
+        self._insert(operation["insert"])
+
+
+class Trade(DataStore):
+    _MAXLEN = 99999
+
+    def _onmessage(self, msg: Item, topic_ext: list[str]) -> None:
+        self._insert(msg["data"])
+
+
+class Ticker(DataStore):
+    _KEYS = ["symbol"]
+
+    def _onmessage(self, msg: Item, topic_ext: list[str]) -> None:
+        self._update([msg["data"]])
+
+
+class Kline(DataStore):
+    _KEYS = ["symbol", "start", "end"]
+
+    def _onmessage(self, msg: Item, topic_ext: list[str]) -> None:
+        msg["data"] = [{"symbol": topic_ext[1], **x} for x in msg["data"]]
+        self._update(msg["data"])
+
+
+class Liquidation(DataStore):
+    _MAXLEN = 99999
+
+    def _onmessage(self, msg: Item, topic_ext: list[str]) -> None:
+        self._insert([msg["data"]])
+
+
+class LTKline(Kline):
+    ...
+
+
+class LTTicker(Ticker):
+    ...
+
+
+class LTNav(Ticker):
+    ...
+
+
+class Position(DataStore):
+    _KEYS = ["symbol", "positionIdx"]
+
+    def _onmessage(self, msg: Item, topic_ext: list[str]) -> None:
+        self._update(msg["data"])
+
+
+class Execution(DataStore):
+    _MAXLEN = 99999
+
+    def _onmessage(self, msg: Item, topic_ext: list[str]) -> None:
+        self._insert(msg["data"])
+
+
+class Order(DataStore):
+    _KEYS = ["orderId"]
+
+    def _onmessage(self, msg: Item, topic_ext: list[str]) -> None:
+        map_order_status = {
+            "Created": "pending",
+            "New": "pending",
+            "Rejected": "failure",
+            "PartiallyFilled": "pending",
+            "PartiallyFilledCanceled": "filled",
+            "Filled": "filled",
+            "Cancelled": "canceled",
+            "Untriggered": "pending",
+            "Triggered": "filled",
+            "Deactivated": "canceled",
+            "Active": "pending",
+        }
+
+        for item in msg["data"]:
+            order_status = map_order_status.get(item["orderStatus"])
+            if order_status == "pending":
+                self._update([item])
+            elif order_status in ("filled", "canceled", "failure"):
+                self._delete([item])
+                if item["orderLinkId"]:  # delete conditional order for spot
+                    self._delete(self.find({"orderLinkId": item["orderLinkId"]}))
+
+
+class Wallet(DataStore):
+    _KEYS = ["accountType"]
+
+    def _onmessage(self, msg: Item, topic_ext: list[str]) -> None:
+        self._update(msg["data"])
+
+
+class Greek(DataStore):
+    _KEYS = ["greeks"]
+
+    def _onmessage(self, msg: Item, topic_ext: list[str]) -> None:
+        self._update(msg["data"])

--- a/pybotters/models/bybit_v5.py
+++ b/pybotters/models/bybit_v5.py
@@ -27,7 +27,7 @@ class BybitV5DataStore(DataStoreManager):
         self.create("execution", datastore_class=Execution)
         self.create("order", datastore_class=Order)
         self.create("wallet", datastore_class=Wallet)
-        self.create("greek", datastore_class=Greek)
+        self.create("greeks", datastore_class=Greek)
 
     async def initialize(self, *aws: Awaitable[aiohttp.ClientResponse]) -> None:
         """
@@ -112,7 +112,7 @@ class BybitV5DataStore(DataStoreManager):
 
     @property
     def greek(self) -> "Greek":
-        return self.get("greek", Greek)
+        return self.get("greeks", Greek)
 
 
 class OrderBook(DataStore):
@@ -247,7 +247,7 @@ class Wallet(DataStore):
 
 
 class Greek(DataStore):
-    _KEYS = ["greeks"]
+    _KEYS = ["baseCoin"]
 
     def _onmessage(self, msg: Item, topic_ext: list[str]) -> None:
         self._update(msg["data"])

--- a/pybotters/models/bybit_v5.py
+++ b/pybotters/models/bybit_v5.py
@@ -243,7 +243,14 @@ class Wallet(DataStore):
     _KEYS = ["accountType"]
 
     def _onmessage(self, msg: Item, topic_ext: list[str]) -> None:
-        self._update(msg["data"])
+        for item in msg["data"]:
+            orig_item = self.get(item)
+            if orig_item:
+                current_coins = set(map(lambda x: x["coin"], item["coin"]))
+                item["coin"].extend(
+                    filter(lambda x: x["coin"] not in current_coins, orig_item["coin"])
+                )
+            self._update([item])
 
 
 class Greek(DataStore):

--- a/pybotters/models/bybit_v5.py
+++ b/pybotters/models/bybit_v5.py
@@ -40,7 +40,9 @@ class BybitV5DataStore(DataStoreManager):
         """
         対応エンドポイント
 
-        - GET /v2/private/order (DataStore: order)
+        - GET /v5/position/list (DataStore: position)
+        - GET /v5/order/realtime (DataStore: order)
+        - GET /v5/account/wallet-balance (DataStore: wallet)
         """
         for f in asyncio.as_completed(aws):
             resp = await f


### PR DESCRIPTION
## 変更内容

Bybit V5 WebSocket API [^1] の DataStore をサポートする。

クラス名: `BybitV5DataStore`

[^1]: https://bybit-exchange.github.io/docs/v5/ws/connect

## 動作確認

UNIFIED, CONTRACT それぞれの口座で全てのトピックデータを検証済み。

## トピックのサポート

PR 時点で公開されている WebSocket より購読可能な全ての Public / Private Topics をサポートしている。
REST API からの初期化は、position, order, wallet をサポートしている。

**Public Topics**

- Orderbook
- Trade
- Ticker
- Kline
- Liquidation
- LT Kline
- LT Ticker
- LT Nav

**Public Topics**

- Position (✔ initialize)
- Execution
- Order (✔ initialize)
- Wallet (✔ initialize)
- Greek

## 仕様

基本的に各トピック配信データの `"data"` フィールドを DataStore のアイテムとして格納する。
DataStore のアイテムとして格納する為にデータを加工しているなどのトピック個別の仕様については以下に記す。

### Orderbook

配列になっている価格とサイズフィールドの命名及び、構造的なオブジェクトとなっているデータを DataStore に格納できるよう二次元化している。

オリジナルデータ
```jsonc
{
    "topic": "orderbook.50.BTCUSDT",
    "type": "snapshot",
    "ts": 1672304484978,
    "data": {
        "s": "BTCUSDT",
        "b": [
            ...,
            [
                "16493.50",
                "0.006"
            ],
            [
                "16493.00",
                "0.100"
            ]
        ],
        "a": [
            [
                "16611.00",
                "0.029"
            ],
            [
                "16612.00",
                "0.213"
            ],
            ...,
        ],
        "u": 18521288,
        "seq": 7961638724
    }
}
```

DataStore
```py
# s -> symbol, b -> side.bids, a-> side.asks, array[0] -> price, array[1] -> size
[
    {"symbol": "BTCUSDT", "side": "bids", "price": "16493.50", "size": "0.006"},
    {"symbol": "BTCUSDT", "side": "bids", "price": "16493.00", "size": "0.100"},
    {"symbol": "BTCUSDT", "side": "asks", "price": "16611.00", "size": "0.029"},
    {"symbol": "BTCUSDT", "side": "asks", "price": "16612.00", "size": "0.213"},
]
```

また他の DataStore 同様、板ストアのみ `sorted` メソッドを実装している。 `sorted` メソッドはストア内の板データを Ask / Bid で振り分けられたオブジェクトを返す。

`sorted`
```py
{
    "asks": [
        {"symbol": "BTCUSDT", "side": "asks", "price": "16611.00", "size": "0.029"},
        {"symbol": "BTCUSDT", "side": "asks", "price": "16612.00", "size": "0.213"},
    ],
    "bids": [
        {"symbol": "BTCUSDT", "side": "bids", "price": "16493.50", "size": "0.006"},
        {"symbol": "BTCUSDT", "side": "bids", "price": "16493.00", "size": "0.100"},
    ],
}
```

### Kline

`"data"` 内にキーとなるシンボル名がない為 `"topic"` からシンボル名を解釈してアイテムに追加している。

オリジナルデータ
```jsonc
{
    "topic": "kline.5.BTCUSDT",
    "data": [
        {
            "start": 1672324800000,
            "end": 1672325099999,
            "interval": "5",
            "open": "16649.5",
            "close": "16677",
            "high": "16677",
            "low": "16608",
            "volume": "2.081",
            "turnover": "34666.4005",
            "confirm": false,
            "timestamp": 1672324988882
        }
    ],
    "ts": 1672324988882,
    "type": "snapshot"
}
```

DataStore
```py
[
    {
        "symobl": "BTCUSDT",  # 追加
        "start": 1672324800000,
        "end": 1672325099999,
        "interval": "5",
        "open": "16649.5",
        "close": "16677",
        "high": "16677",
        "low": "16608",
        "volume": "2.081",
        "turnover": "34666.4005",
        "confirm": false,
        "timestamp": 1672324988882
    }
]
```

### Position

#### initialize

Position を initialize する時の REST API のリクエストパラメーターはシンボル指定を推奨する。

DataStore の個別の仕様ではないが、REST API 側の仕様としてリクエストパラメーターがシンボル指定ではない (`baseCoin` or `settleCoin` を指定する) 場合は ** **ゼロポジションのシンボルの情報が返されない** ** [^2] 。

[^2]: https://bybit-exchange.github.io/docs/v5/position#:~:text=If%20symbol%3Dnull%2C%20it%20returns%20position%20size%20grater%20than%20zero.

その為、コイン指定のリクエストパラメーターで Position の initialize をしてもゼロポジションのシンボルの情報は DataStore にも格納されない注意が必要。

### Order

他の DataStore と同様、アクティブなオーダーのみデータを格納して、非アクティブなオーダーはストアから削除する。
`"orderId"` をキーとしてオーダーを管理しているが、 Bybit 現物の条件付きオーダーのみ状態が変化すると ID が変化し実質的に `"orderLinkId"` がキーとなっている為、オーダーが非アクティブになった際 `"orderLinkId"` に紐づくアイテムがあれば削除する。

### Wallet

Wallet ストアキーは `"accountType"` としている。 REST API 側仕様で `CONTRACT` アカウントにおいては `"coin"` フィールドのみが利用可能で、他のフィールドデータは空で利用できない為注意が必要。

また `"coin"` フィールドはリストオブジェクトになっている為、通常であれば差分データはリストを新しいリストで上書きしてしまうが、 DataStore で独自にリストをマージする処理を行っている為、 `"coin"` フィールドの差分データも格納することができる。

オリジナルデータ
```jsonc
{
    "id": "5923242c464be9-25ca-483d-a743-c60101fc656f",
    "topic": "wallet",
    "creationTime": 1672364262482,
    "data": [
        {
            "accountIMRate": "0.016",
            "accountMMRate": "0.003",
            "totalEquity": "12837.78330098",
            "totalWalletBalance": "12840.4045924",
            "totalMarginBalance": "12837.78330188",
            "totalAvailableBalance": "12632.05767702",
            "totalPerpUPL": "-2.62129051",
            "totalInitialMargin": "205.72562486",
            "totalMaintenanceMargin": "39.42876721",
            "coin": [
                {
                    "coin": "USDC",
                    "equity": "200.62572554",
                    "usdValue": "200.62572554",
                    "walletBalance": "201.34882644",
                    "availableToWithdraw": "0",
                    "availableToBorrow": "1500000",
                    "borrowAmount": "0",
                    "accruedInterest": "0",
                    "totalOrderIM": "0",
                    "totalPositionIM": "202.99874213",
                    "totalPositionMM": "39.14289747",
                    "unrealisedPnl": "74.2768991",
                    "cumRealisedPnl": "-209.1544627",
                    "bonus": "0"
                },
                {
                    "coin": "USDT",
                    "equity": "11726.64664904",
                    "usdValue": "11613.58597018",
                    "walletBalance": "11728.54414904",
                    "availableToWithdraw": "11723.92075829",
                    "availableToBorrow": "2500000",
                    "borrowAmount": "0",
                    "accruedInterest": "0",
                    "totalOrderIM": "0",
                    "totalPositionIM": "2.72589075",
                    "totalPositionMM": "0.28576575",
                    "unrealisedPnl": "-1.8975",
                    "cumRealisedPnl": "0.64782276",
                    "bonus": "0"
                }
            ],
            "accountType": "UNIFIED"
        }
    ]
}
```