### PR TITLE
Fix KuCoin signatures affected by HTTP methods

### DIFF
--- a/pybotters/auth.py
+++ b/pybotters/auth.py
@@ -383,16 +383,14 @@ class Auth:
         passphrase: str = session.__dict__["_apis"][Hosts.items[url.host].name][2]
 
         now = int(time.time() * 1000)
-        if method == "GET":
-            str_to_sign = str(now) + method + url.path_qs
-        else:
-            body = JsonPayload(data) if data else FormData(data)()
-            headers["Content-Type"] = "application/json"
-            kwargs.update({"data": body._value})
-            str_to_sign = str(now) + method + url.path + body._value.decode()
+        body = JsonPayload(data) if data else FormData(data)()
+        if body._value:
+            kwargs.update({"data": body})
+
+        str_to_sign = f"{now}{method}{url.path_qs}".encode() + body._value
 
         signature = base64.b64encode(
-            hmac.new(secret, str_to_sign.encode("utf-8"), hashlib.sha256).digest()
+            hmac.new(secret, str_to_sign, hashlib.sha256).digest()
         ).decode()
         passphrase = base64.b64encode(
             hmac.new(secret, passphrase.encode("utf-8"), hashlib.sha256).digest()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1229,10 +1229,9 @@ def test_kucoin_post(mock_session, mocker: pytest_mock.MockerFixture):
                 "price": "19200",
                 "size": 1,
             }
-        )._value,
+        ),
         "headers": CIMultiDict(
             {
-                "Content-Type": "application/json",
                 "KC-API-SIGN": "aoxLuRURO0t1z9hhh9ERbHjVp6bJ1K5bfoU2xHH25Y4=",
                 "KC-API-TIMESTAMP": "2085848896000",
                 "KC-API-KEY": "CYdTygFbGgM1re2J54lU2t83",
@@ -1244,5 +1243,5 @@ def test_kucoin_post(mock_session, mocker: pytest_mock.MockerFixture):
     }
     args = pybotters.auth.Auth.kucoin(args, kwargs)
     assert args == expected_args
-    assert kwargs["data"] == expected_kwargs["data"]
+    assert kwargs["data"]._value == expected_kwargs["data"]._value
     assert kwargs["headers"] == expected_kwargs["headers"]


### PR DESCRIPTION
## Overview

#230 の検証中、KuCoin API の HTTP DELETE リクエストにて署名に問題があり認証が失敗する問題があった為修正する。