### PR TITLE
Integrate KuCoin API name

### DIFF
--- a/pybotters/request.py
+++ b/pybotters/request.py
@@ -28,7 +28,7 @@ class ClientRequest(aiohttp.ClientRequest):
                 if isinstance(Hosts.items[url.host].name, str):
                     api_name = Hosts.items[url.host].name
                 elif callable(Hosts.items[url.host].name):
-                    api_name = Hosts.items[url.host].name(kwargs["headers"])
+                    api_name = Hosts.items[url.host].name(args, kwargs)
                 if api_name in kwargs["session"].__dict__["_apis"]:
                     args = Hosts.items[url.host].func(args, kwargs)
 


### PR DESCRIPTION
## Overview

以前 KuCoin の API キーは現物用と先物用で独立しており、両方利用したい場合はそれぞれで APK キーの発行が必要になっていました。 pybotters の API 情報辞書でもそれに対応して辞書キー `"kucoinspot" "kucoinfuture"` でそれぞれ定義してありました。


```json
{
    "kucoinspot": ["KUCOIN_SPOT_API_KEY", "KUCOIN_SPOT_API_SECRET", "KUCOIN_SPOT_API_PASSPHRASE"],
    "kucoinfuture": ["KUCOIN_FUTURE_API_KEY", "KUCOIN_FUTURE_API_SECRET", "KUCOIN_FUTURE_API_PASSPHRASE"]
}
```

しかし現在の KuCoin の仕様は API キーは独立ではなく共通の仕様に更新されていることが確認できました。

![image](https://github.com/MtkN1/pybotters/assets/51289448/b9ab613c-b11e-4862-92a3-4bc66d926ba6)

その為 pybotters の API 情報辞書でもその仕様に対応して辞書キー `"kucoin"` で API 情報を読み込み出来るように変更します。 なお既存ユーザーと互換性を保つために `"kucoinspot" "kucoinfuture"` も引き続き利用することができます。 ただし `"kucoin"` があれば優先して認証に利用されます。

```json
{
    # Recommended
    "kucoin": ["KUCOIN_COMMON_API_KEY", "KUCOIN_COMMON_API_SECRET", "KUCOIN_COMMON_API_PASSPHRASE"],
    # For compatibility
    "kucoinspot": ["KUCOIN_SPOT_API_KEY", "KUCOIN_SPOT_API_SECRET", "KUCOIN_SPOT_API_PASSPHRASE"],
    "kucoinfuture": ["KUCOIN_FUTURE_API_KEY", "KUCOIN_FUTURE_API_SECRET", "KUCOIN_FUTURE_API_PASSPHRASE"]
}
```

### Internal changes

- pybotters.authNameSelector クラスにおける動的な API 名取得関数のインターフェースを変更します。 ヘッダーのみを引数としていたのを、署名系関数と同様の args, kwargs が引数となります。
- それに伴いインターフェースの変更に影響のある OKX の API 名取得関数をリファクタリングしました。