### PR TITLE
Wait for WebSocket login to complete in Bitget

### DIFF
--- a/pybotters/ws.py
+++ b/pybotters/ws.py
@@ -424,6 +424,21 @@ class Auth:
             ],
         }
         await ws.send_json(msg, _itself=True)
+        async for msg in ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                try:
+                    data = msg.json()
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    if "event" in data:
+                        if data["event"] == "login":
+                            break
+                        elif data["event"] == "error":
+                            logger.warning(data)
+                            break
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                break
 
     @staticmethod
     async def mexc(ws: aiohttp.ClientWebSocketResponse):

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -396,7 +396,13 @@ async def test_bitget_ws(mocker: pytest_mock.MockerFixture):
     }
     ws.send_json.side_effect = dummy_send
 
-    await pybotters.ws.Auth.bitget(ws)
+    if sys.version_info.major == 3 and sys.version_info.minor == 7:
+        with pytest.raises(TypeError):
+            await pybotters.ws.Auth.bitget(ws)
+    elif sys.version_info.major == 3 and sys.version_info.minor > 7:
+        await pybotters.ws.Auth.bitget(ws)
+    else:
+        raise RuntimeError(f"Unsupported Python version: {sys.version}")
 
 
 def test_websocketrunner(mocker: pytest_mock.MockerFixture):


### PR DESCRIPTION
## 変更内容

Bitget の WebSocket プライベートチャンネル購読時、ログインレスポンスより先に購読リクエストのメッセージが送信される仕様になっていたので、ある時から以下のようなレスポンスが表示され認証失敗によりプライベートチャンネルが購読できなくなっていた。

```py
{'event': 'error', 'code': 30004, 'msg': 'User not logged in/User must be logged in'}
```

他の取引所の WebSocket 認証処理でも行っているように、ログインレスポンスを待つ処理を追加する。

## テストコード

```py
import asyncio
import pybotters


async def main():
    async with pybotters.Client(base_url="https://api.bitget.com") as client:
        ws = await client.ws_connect(
            "wss://ws.bitget.com/spot/v1/stream",
            send_json={
                "op": "subscribe",
                "args": [
                    {"instType": "spbl", "channel": "account", "instId": "default"}
                ],
            },
        )
        await ws


try:
    asyncio.run(main())
except KeyboardInterrupt:
    pass
```