### PR TITLE
Add fetch API

### DIFF
--- a/pybotters/__init__.py
+++ b/pybotters/__init__.py
@@ -9,7 +9,7 @@ import aiohttp
 from aiohttp import hdrs
 from rich import print
 
-from .client import Client
+from .client import Client, FetchResult
 from .models.binance import (
     BinanceCOINMDataStore,
     BinanceSpotDataStore,
@@ -19,8 +19,8 @@ from .models.bitbank import bitbankDataStore
 from .models.bitflyer import bitFlyerDataStore
 from .models.bitget import BitgetDataStore
 from .models.bitmex import BitMEXDataStore
-from .models.bybit_v5 import BybitV5DataStore
 from .models.bybit import BybitInverseDataStore, BybitUSDTDataStore
+from .models.bybit_v5 import BybitV5DataStore
 from .models.coincheck import CoincheckDataStore
 from .models.deprecated.binance import BinanceDataStore
 from .models.deprecated.bybit import BybitDataStore
@@ -33,6 +33,7 @@ from .ws import WebSocketQueue
 
 __all__: Tuple[str, ...] = (
     "Client",
+    "FetchResult",
     "request",
     "get",
     "post",

--- a/pybotters/client.py
+++ b/pybotters/client.py
@@ -10,13 +10,17 @@ from typing import Any, Mapping, Optional, Union
 import aiohttp
 from aiohttp import hdrs
 from aiohttp.client import _RequestContextManager
-from typing_extensions import Literal
 
 from . import __version__
 from .auth import Auth
 from .request import ClientRequest
 from .typedefs import WsBytesHandler, WsJsonHandler, WsStrHandler
 from .ws import ClientWebSocketResponse, WebSocketRunner
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

HTTP リクエスト／レスポンスに関する頻出する処理のショートカットを `pybotters.Client.fetch` メソッドとして実装します。

pybotters の fetch API は aiohttp における冗長的な処理ステップを省略して 1 つの `await` 文で HTTP リクエスト／レスポンスを受け取り、JSON 形式の本文をデコードしたデータを受け取ることができます。

```python
# aiohttp usage
async with pybotters.Client() as client:
    async with client.get("https://...") as resp:
        data = await resp.json()
    print(data)

# fetch API usage
async with pybotters.Client() as client:
    r = await client.fetch("GET", "https://...")
    print(r.data)
```

fetch API は await 後 `pybotters.FetchResult` を返します。 これは dataclass となっており、`response` プロパティに aiohttp のレスポンスクラス、`data` にデコードされた JSON コンテンツが格納されます。 詳細は以下のリファレンスをご確認ください。

## Reference

`pybotters.Client.fetch()`

- Args
    - `pybotters.Client.request` と同等です。
- Returns
    - `pybotters.FetchResult` を返します。
        - `response`: `aiohttp.ClientResponse`
            - 通常の aiohttp レスポンスクラスです。
        - `text`: `str`
            - `await response.text()` の結果です。
        - `data`: `Any | json.JSONDecodeError`
            - `await response.json()` の結果です。
            - HTTP 本文が JSON ではないなどデコードエラーが発生した場合、`json.JSONDecodeError` の例外が格納されます。

## Example

bitFlyer から Ticker 情報を取得して、ステータスコードとデータを表示するサンプルです。

```python
import asyncio

import pybotters


async def main():
    async with pybotters.Client() as client:
        r = await client.fetch(
            "GET",
            "https://api.bitflyer.com/v1/getticker",
            params={"product_code": "FX_BTC_JPY"},
        )

        print(type(r), r.response.status, r.response.reason)
        print(r.data)


asyncio.run(main())
``` 