### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
Read the Docs のビルドが失敗していた問題を修正します。

https://readthedocs.org/projects/pybotters/builds/21953395/

> エラー
> The configuration key "build.os" is required to build your documentation. Read more at https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os

設定ファイル `.readthedocs.yml` がなく必須項目が設定されていなかったことが原因の模様です。