### PR TITLE
Fix signatures when no parameters are specified in MEXC

### DIFF
--- a/pybotters/auth.py
+++ b/pybotters/auth.py
@@ -345,23 +345,16 @@ class Auth:
         query = MultiDict(url.query)
         body = FormData(data)()
 
-        if query:
-            query.extend({"timestamp": timestamp})
-            url = url.with_query(query)
-            query = MultiDict(url.query)
-        else:
-            body._value += f"&timestamp={timestamp}".encode()
+        query.extend({"timestamp": timestamp})
+        url = url.with_query(query)
+        query = MultiDict(url.query)
 
         query_string = url.raw_query_string.encode()
         signature = hmac.new(
             secret, query_string + body._value, hashlib.sha256
         ).hexdigest()
 
-        if query:
-            query.extend({"signature": signature})
-        else:
-            body._value += f"&signature={signature}".encode()
-            body._size += len(body._value)
+        query.extend({"signature": signature})
 
         url = url.with_query(query)
         args = (method, url)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1123,6 +1123,40 @@ def test_mexc_v2_post(mock_session, mocker: pytest_mock.MockerFixture):
 
 def test_mexc_v3_get(mock_session, mocker: pytest_mock.MockerFixture):
     mocker.patch("time.time", return_value=2085848896.0)
+
+    # without query
+    args = (
+        "GET",
+        URL("https://api.mexc.com/api/v3/account"),
+    )
+    kwargs = {
+        "data": None,
+        "headers": CIMultiDict(),
+        "session": mock_session,
+    }
+    expected_args = (
+        "GET",
+        URL(
+            "https://api.mexc.com/api/v3/account?timestamp=2085848896000&signature=bea4"
+            "958a74f3d56f984e7fafd012cb2474813ff98d857b9e75d5eb46e4bcc5bc"
+        ),
+    )
+    expected_kwargs = {
+        "data": b"",
+        "headers": CIMultiDict(
+            {
+                "X-MEXC-APIKEY": "0uVJRVNmR2ZHiCXtf6yEwrwy",
+                "Content-Type": "application/json",
+            }
+        ),
+        "session": mock_session,
+    }
+    args = pybotters.auth.Auth.mexc_v3(args, kwargs)
+    assert args == expected_args
+    assert kwargs["data"] == expected_kwargs["data"]
+    assert kwargs["headers"] == expected_kwargs["headers"]
+
+    # with query
     args = (
         "GET",
         URL("https://api.mexc.com/api/v3/openOrders").with_query(
@@ -1176,7 +1210,13 @@ def test_mexc_v3_post(mock_session, mocker: pytest_mock.MockerFixture):
         "headers": CIMultiDict(),
         "session": mock_session,
     }
-    expected_args = ("POST", URL("https://api.mexc.com/api/v3/order"))
+    expected_args = (
+        "POST",
+        URL(
+            "https://api.mexc.com/api/v3/order?timestamp=2085848896000&signature=692fc1"
+            "41d6a0bb9abc90714e253369b715b74c115358d9cbf6f450bdde688fdd"
+        ),
+    )
     expected_kwargs = {
         "data": aiohttp.formdata.FormData(
             {
@@ -1184,10 +1224,6 @@ def test_mexc_v3_post(mock_session, mocker: pytest_mock.MockerFixture):
                 "side": "BUY",
                 "type": "MARKET",
                 "quoteOrderQty": "5",
-                "timestamp": "2085848896000",
-                "signature": (
-                    "4b5e31a683df50d43d4e0774fafb869e1b4d517f8fdbff23c275092517c84161"
-                ),
             }
         )()._value,
         "headers": CIMultiDict(


### PR DESCRIPTION
## Summary

MEXC の認証ロジックにて、パラメータなしの GET リクエストなどが正常に署名されない問題を修正します。

再現例:
```py
async def main():
    async with pybotters.Client(base_url="https://api.mexc.com") as client:
        r = await client.fetch("GET", "/api/v3/account")
        print(repr(r.response).splitlines()[0])
        print(r.data)
```
```
<ClientResponse(https://api.mexc.com/api/v3/account) [400 Bad Request]>
{'code': 700004, 'msg': "Mandatory parameter 'signature' was not sent, was empty/null, or malformed."}
```

## Changes

- この変更の副作用にて、pybotters が自動付与する署名情報 `signature` は GET 系リクエストでは URL クエリ、POST 系リクエストではボディに付与されていましたが、リクエスト方法を問わずに URL クエリに付与されるようになります。