### PR TITLE
Change Fetch API error data

### DIFF
--- a/pybotters/__init__.py
+++ b/pybotters/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 __version__ = "0.17.0"
 
 
-from .client import Client, FetchResult
+from .client import Client, FetchResult, NotJSONContent
 from .models.binance import (
     BinanceCOINMDataStore,
     BinanceSpotDataStore,
@@ -25,6 +25,7 @@ __all__: tuple[str, ...] = (
     # client
     "Client",
     "FetchResult",
+    "NotJSONContent",
     # ws
     "WebSocketQueue",
     # models

--- a/pybotters/client.py
+++ b/pybotters/client.py
@@ -162,9 +162,9 @@ class Client:
         ) as resp:
             text = await resp.text()
             try:
-                data = await resp.json()
+                data = await resp.json(content_type=None)
             except json.JSONDecodeError as e:
-                data = e
+                data = NotJSONContent(error=e)
 
         return FetchResult(response=resp, text=text, data=data)
 
@@ -292,4 +292,12 @@ class Client:
 class FetchResult:
     response: aiohttp.ClientResponse
     text: str
-    data: Any | json.JSONDecodeError
+    data: Any | NotJSONContent
+
+
+@dataclass
+class NotJSONContent:
+    error: json.JSONDecodeError
+
+    def __bool__(self) -> Literal[False]:
+        return False

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -142,7 +142,8 @@ async def test_client_fetch_error(mocker: pytest_mock.MockerFixture):
     assert isinstance(r, pybotters.FetchResult)
     assert isinstance(r.response, type(m_resp))
     assert r.text == m_resp.text.return_value
-    assert isinstance(r.data, json.JSONDecodeError)
+    assert isinstance(r.data, pybotters.NotJSONContent)
+    assert not r.data
     assert m_req.called
 
 


### PR DESCRIPTION
## Summary

- #243

にて実装した Fetch API ですが、JSON パースエラー時には `json.JSONDecodeError` の例外を格納する仕様でしたが、これにはひとつ問題がありました。

`json.JSONDecodeError` の例外の評価は Truthy です。 ユーザーコードで `if r.data:` のようにレスポンスデータの便宜的なチェックを行うと、それをパスしてしまいます。 予期する期待としてはエラー時はこの if は通らないことです。

この修正では、JSON パースエラー時は独自のクラス `NotJSONContent` を格納するようにします。 このクラスの評価は Falsy となっているので、上記の問題を解決できます。

## Changes

- `FetchResult.data` の型を `Any | json.JSONDecodeError` -> `Any | NotJSONContent` に変更します
- Top-level から `pybotters.NotJSONContent` としてクラスを公開します

## Reference

- `NotJSONContent`
    - `error`: `json.JSONDecodeError`