### PR TITLE
Remove KuCoin API name compatibility

### DIFF
--- a/pybotters/auth.py
+++ b/pybotters/auth.py
@@ -371,10 +371,9 @@ class Auth:
         headers: CIMultiDict = kwargs["headers"]
 
         session: aiohttp.ClientSession = kwargs["session"]
-        api_name = DynamicNameSelector.kucoin(args, kwargs)
-        key: str = session.__dict__["_apis"][api_name][0]
-        secret: bytes = session.__dict__["_apis"][api_name][1]
-        passphrase: str = session.__dict__["_apis"][api_name][2]
+        key: str = session.__dict__["_apis"][Hosts.items[url.host].name][0]
+        secret: bytes = session.__dict__["_apis"][Hosts.items[url.host].name][1]
+        passphrase: str = session.__dict__["_apis"][Hosts.items[url.host].name][2]
 
         now = int(time.time() * 1000)
         body = JsonPayload(data) if data else FormData(data)()
@@ -417,26 +416,6 @@ class DynamicNameSelector:
                 return "okx_demo"
         return "okx"
 
-    @staticmethod
-    def kucoin(args: tuple[str, URL], kwargs: dict[str, Any]) -> str:
-        url: URL = args[1]
-        session: aiohttp.ClientSession = kwargs["session"]
-
-        # KuCoin's API keys for Spot and Futures, which were previously independent,
-        # have been consolidated into a common API key.
-
-        # for common API key name
-        if "kucoin" in session.__dict__["_apis"]:
-            return "kucoin"
-        # Migration for previous API key name
-        else:
-            if url.host == "api.kucoin.com":
-                return "kucoinspot"
-            elif url.host == "api-futures.kucoin.com":
-                return "kucoinfuture"
-            else:
-                return "kucoin"
-
 
 class Hosts:
     items = {
@@ -475,6 +454,6 @@ class Hosts:
         "www.mexc.com": Item("mexc", Auth.mexc_v2),
         "contract.mexc.com": Item("mexc", Auth.mexc_v2),
         "api.mexc.com": Item("mexc", Auth.mexc_v3),
-        "api.kucoin.com": Item(DynamicNameSelector.kucoin, Auth.kucoin),
-        "api-futures.kucoin.com": Item(DynamicNameSelector.kucoin, Auth.kucoin),
+        "api.kucoin.com": Item("kucoin", Auth.kucoin),
+        "api-futures.kucoin.com": Item("kucoin", Auth.kucoin),
     }

--- a/pybotters/auth.py
+++ b/pybotters/auth.py
@@ -241,7 +241,7 @@ class Auth:
         headers: CIMultiDict = kwargs["headers"]
 
         session: aiohttp.ClientSession = kwargs["session"]
-        api_name = NameSelector.okx(args, kwargs)
+        api_name = DynamicNameSelector.okx(args, kwargs)
         key: str = session.__dict__["_apis"][api_name][0]
         secret: bytes = session.__dict__["_apis"][api_name][1]
         passphrase: str = session.__dict__["_apis"][api_name][2]
@@ -371,7 +371,7 @@ class Auth:
         headers: CIMultiDict = kwargs["headers"]
 
         session: aiohttp.ClientSession = kwargs["session"]
-        api_name = NameSelector.kucoin(args, kwargs)
+        api_name = DynamicNameSelector.kucoin(args, kwargs)
         key: str = session.__dict__["_apis"][api_name][0]
         secret: bytes = session.__dict__["_apis"][api_name][1]
         passphrase: str = session.__dict__["_apis"][api_name][2]
@@ -407,7 +407,7 @@ class Item:
     func: Any
 
 
-class NameSelector:
+class DynamicNameSelector:
     @staticmethod
     def okx(args: tuple[str, URL], kwargs: dict[str, Any]) -> str:
         headers: CIMultiDict = kwargs["headers"]
@@ -469,12 +469,12 @@ class Hosts:
         "vapi.phemex.com": Item("phemex", Auth.phemex),
         "testnet-api.phemex.com": Item("phemex_testnet", Auth.phemex),
         "coincheck.com": Item("coincheck", Auth.coincheck),
-        "www.okx.com": Item(NameSelector.okx, Auth.okx),
-        "aws.okx.com": Item(NameSelector.okx, Auth.okx),
+        "www.okx.com": Item(DynamicNameSelector.okx, Auth.okx),
+        "aws.okx.com": Item(DynamicNameSelector.okx, Auth.okx),
         "api.bitget.com": Item("bitget", Auth.bitget),
         "www.mexc.com": Item("mexc", Auth.mexc_v2),
         "contract.mexc.com": Item("mexc", Auth.mexc_v2),
         "api.mexc.com": Item("mexc", Auth.mexc_v3),
-        "api.kucoin.com": Item(NameSelector.kucoin, Auth.kucoin),
-        "api-futures.kucoin.com": Item(NameSelector.kucoin, Auth.kucoin),
+        "api.kucoin.com": Item(DynamicNameSelector.kucoin, Auth.kucoin),
+        "api-futures.kucoin.com": Item(DynamicNameSelector.kucoin, Auth.kucoin),
     }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -130,22 +130,24 @@ def test_item():
 
 
 def test_selector_okx():
-    api_name = pybotters.auth.NameSelector.okx(args=tuple(), kwargs={"headers": {}})
+    api_name = pybotters.auth.DynamicNameSelector.okx(
+        args=tuple(), kwargs={"headers": {}}
+    )
     assert api_name == "okx"
 
-    api_name = pybotters.auth.NameSelector.okx(
+    api_name = pybotters.auth.DynamicNameSelector.okx(
         args=tuple(), kwargs={"headers": {"foo": "bar"}}
     )
     assert api_name == "okx"
 
-    api_name = pybotters.auth.NameSelector.okx(
+    api_name = pybotters.auth.DynamicNameSelector.okx(
         args=tuple(), kwargs={"headers": {"x-simulated-trading": "1"}}
     )
     assert api_name == "okx_demo"
 
 
 def test_selector_kucoin(mock_session, mocker: pytest_mock.MockerFixture):
-    api_name = pybotters.auth.NameSelector.kucoin(
+    api_name = pybotters.auth.DynamicNameSelector.kucoin(
         args=("GET", URL("https://api-kucoin.com")),
         kwargs={"session": mock_session},
     )
@@ -154,13 +156,13 @@ def test_selector_kucoin(mock_session, mocker: pytest_mock.MockerFixture):
     m_sess = mocker.MagicMock()
     m_sess.__dict__["_apis"] = dict()
 
-    api_name = pybotters.auth.NameSelector.kucoin(
+    api_name = pybotters.auth.DynamicNameSelector.kucoin(
         args=("GET", URL("https://api.kucoin.com")),
         kwargs={"session": m_sess},
     )
     assert api_name == "kucoinspot"
 
-    api_name = pybotters.auth.NameSelector.kucoin(
+    api_name = pybotters.auth.DynamicNameSelector.kucoin(
         args=("GET", URL("https://api-futures.kucoin.com")),
         kwargs={"session": m_sess},
     )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -146,29 +146,6 @@ def test_selector_okx():
     assert api_name == "okx_demo"
 
 
-def test_selector_kucoin(mock_session, mocker: pytest_mock.MockerFixture):
-    api_name = pybotters.auth.DynamicNameSelector.kucoin(
-        args=("GET", URL("https://api-kucoin.com")),
-        kwargs={"session": mock_session},
-    )
-    assert api_name == "kucoin"
-
-    m_sess = mocker.MagicMock()
-    m_sess.__dict__["_apis"] = dict()
-
-    api_name = pybotters.auth.DynamicNameSelector.kucoin(
-        args=("GET", URL("https://api.kucoin.com")),
-        kwargs={"session": m_sess},
-    )
-    assert api_name == "kucoinspot"
-
-    api_name = pybotters.auth.DynamicNameSelector.kucoin(
-        args=("GET", URL("https://api-futures.kucoin.com")),
-        kwargs={"session": m_sess},
-    )
-    assert api_name == "kucoinfuture"
-
-
 def test_bybit_get(mock_session, mocker: pytest_mock.MockerFixture):
     mocker.patch("time.time", return_value=2085848896.0)
     args = (


### PR DESCRIPTION
## Summary

- #252

の追加的な変更です。

KuCoin の API 名 (`apis`) の互換性を破棄します。

1. KuCoin は以前現物と先物の API キー／シークレットが別々で管理されており、pybotters は `"kucoinspot"` `"kucoinfuture"` という API 名で対応していました
1. KuCoin はあるタイミングで API の管理を統合したので、pybotters は `"kucoin"` という API 名に対応して、またユーザーの API 名互換性の為 `"kucoin"` が存在しなければ `"kucoinspot"` `"kucoinfuture"` を選択するようにしていました
1. 今回の変更では pybotters v1.0 アップデートのタイミングで `"kucoinspot"` `"kucoinfuture"` の API 名互換性を削除します

## Changes

```jsonc
{
    # 👌 Available
    "kucoin": ["KUCOIN_API_KEY", "KUCOIN_API_SECRET", "KUCOIN_PASSPHRASE"],
    # 💥 Removed
    "kucoinspot": ["KUCOINSPOT_API_KEY", "KUCOINSPOT_API_SECRET", "KUCOINSPOT_PASSPHRASE"],
    # 💥 Removed
    "kucoinfuture": ["KUCOINFUTURE_API_KEY", "KUCOINFUTURE_API_SECRET", "KUCOINFUTURE_API_PASSPHRASE"]
}
```