### PR TITLE
Improve client and store testing

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,8 @@ on: [push, pull_request]
 
 permissions:
   contents: read
+  checks: write
+  pull-requests: write
 
 jobs:
   pytest:
@@ -36,4 +38,10 @@ jobs:
         poetry run flake8
     - name: Test with pytest
       run: |
-        poetry run pytest --cov-report term --cov pybotters tests/
+        poetry run pytest --junitxml=test-results/${{ matrix.python-version }}.xml --cov-report term --cov pybotters tests/
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()
+      with:
+        files: |
+          test-results/*.xml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,4 +36,6 @@ jobs:
         poetry run flake8
     - name: Test with pytest
       run: |
-        poetry run pytest --cov-report term --cov pybotters tests/
+        poetry run pytest --cov-report term --cov-report term --cov-report=xml --cov pybotters tests/
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,3 +39,7 @@ jobs:
         poetry run pytest --cov-report term --cov-report term --cov-report=xml --cov pybotters tests/
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
+      with:
+        env_vars: PYTHON
+        fail_ci_if_error: true
+        flags: unittests

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,8 +7,6 @@ on: [push, pull_request]
 
 permissions:
   contents: read
-  checks: write
-  pull-requests: write
 
 jobs:
   pytest:
@@ -38,10 +36,4 @@ jobs:
         poetry run flake8
     - name: Test with pytest
       run: |
-        poetry run pytest --junitxml=test-results/${{ matrix.python-version }}.xml --cov-report term --cov pybotters tests/
-    - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      if: always()
-      with:
-        files: |
-          test-results/*.xml
+        poetry run pytest --cov-report term --cov pybotters tests/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,4 +36,4 @@ jobs:
         poetry run flake8
     - name: Test with pytest
       run: |
-        poetry run pytest
+        poetry run pytest --cov-report term --cov pybotters tests/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 [![pytest](https://github.com/MtkN1/pybotters/actions/workflows/pytest.yml/badge.svg)](https://github.com/MtkN1/pybotters/actions/workflows/pytest.yml)
 [![publish](https://github.com/MtkN1/pybotters/actions/workflows/publish.yml/badge.svg)](https://github.com/MtkN1/pybotters/actions/workflows/publish.yml)
+[![codecov](https://codecov.io/gh/MtkN1/pybotters/graph/badge.svg?token=ARR29R726W)](https://codecov.io/gh/MtkN1/pybotters)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Documentation Status](https://readthedocs.org/projects/pybotters/badge/?version=latest)](https://pybotters.readthedocs.io/ja/latest/?badge=latest)
 

--- a/pybotters/client.py
+++ b/pybotters/client.py
@@ -277,11 +277,7 @@ class Client:
             return {}
 
     @staticmethod
-    def _encode_apis(
-        apis: Optional[dict[str, list[str]]]
-    ) -> dict[str, tuple[str | bytes, ...]]:
-        if apis is None:
-            apis = {}
+    def _encode_apis(apis: dict[str, list[str]]) -> dict[str, tuple[str | bytes, ...]]:
         encoded = {}
         for name in apis:
             if len(apis[name]) >= 2:


### PR DESCRIPTION
## Summary

- `client.py` と `store.py` のテストカバレッジを 100% にします
- `pybotters.Client._encode_apis` の無駄なステップをリファクタします
- GitHub Actions ワークフローにカバレッジ率のターミナル出力を追加します
- GitHub Actions ワークフローに codecov.io へのカバレッジアップロードを追加します
- README.md に codecov のバッジを追加します