### PR TITLE
Improve WebScoket auth

### DIFF
--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -1380,6 +1380,7 @@ async def test_ratelimit_gmocoin(mocker: pytest_mock.MockerFixture):
         AssertionError(),
     ]
     m_wsresp = AsyncMock()
+    m_wsresp._lock = AsyncMock()
     m_wsresp._response._session.get.return_value = m_resp
     m_send_str = AsyncMock().send_str()
 
@@ -1404,6 +1405,7 @@ async def test_ratelimit_binance(mocker: pytest_mock.MockerFixture):
         AssertionError(),
     ]
     m_wsresp = AsyncMock()
+    m_wsresp._lock = AsyncMock()
     m_wsresp._response._session.get.return_value = m_resp
     m_send_str = AsyncMock().send_str()
 


### PR DESCRIPTION
## Summary

WebSocket の認証周りのコードを改善、バグ修正します。

またテストコード向上により `ws.py` のテストカバレッジが 100 % になります 🎊🎊 (これで `models/` 以外のカバレッジは全て 100 % です！)

## Changes

- Remove: 廃止されている Bybit V1 Spot の WebSocket 認証を削除します
- Modify: 全取引所の WebSocket の認証待ちコードについて、認証失敗時に永久待機を避ける仕様に統一します
- Modify: 非 JSON の "ping", "pong" 文字列の JSON デコードエラーによる Warning ログを抑制します
- Fix: KuCoin の WebSocket ホスト名を最新化します
- Fix: Phemx の WebSocket ホスト名を最新化します
- Fix: Binance の "WebSocket API" でメッセージに `"params"` がない場合認証されないバグを修正します
- Fix: WebSocket 側の Binance Spot Testnet の API 名が #256 に追随していない問題を修正します
- Improve: `ws.py` のテスト向上により、基盤部分のテストカバレッジが 100 % になります🎊🎊
    ![image](https://github.com/MtkN1/pybotters/assets/51289448/3b47cb0b-b67c-405b-b60e-73675c0501b6)