### PR TITLE
Add GitHub Action workflow for Copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,3 +1,5 @@
+name: Copilot Setup Steps
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,20 @@
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - run: ./scripts/sync


### PR DESCRIPTION
### Motivation
- Provide an automated GitHub Actions workflow to run repository setup steps used by Copilot and allow manual invocation via dispatch.

### Description
- Add `.github/workflows/copilot-setup-steps.yml` that triggers on `workflow_dispatch`, `push`, and `pull_request` limited to the workflow file.
- Define a `copilot-setup-steps` job running on `ubuntu-latest` with `contents: read` permission.
- Job steps perform `actions/checkout@v6`, `astral-sh/setup-uv@v7`, and execute `./scripts/sync`.

### Testing
- No automated tests were executed as part of this change; the new workflow will run on push, pull request, or manual dispatch when present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da58972700832d97b40594b4530ad7)