### PR TITLE
Fix Binance orderbook reinitialization dropping post-init WebSocket updates

### DIFF
--- a/pybotters/models/binance.py
+++ b/pybotters/models/binance.py
@@ -662,12 +662,14 @@ class Liquidation(DataStore):
 
 class OrderBook(DataStore):
     _KEYS = ["s", "S", "p"]
+    _BUFF_MAXLEN = 8000
 
     def _init(self) -> None:
         self.initialized: defaultdict[str, bool] = defaultdict(lambda: False)
         self._buff: defaultdict[str, deque[Item]] = defaultdict(
-            lambda: deque(maxlen=8000)
+            lambda: deque(maxlen=self._BUFF_MAXLEN)
         )
+        self._last_update_id: dict[str, int] = {}
 
     def sorted(
         self, query: Item | None = None, limit: int | None = None
@@ -682,26 +684,40 @@ class OrderBook(DataStore):
         )
 
     def _onmessage(self, item: Item) -> None:
-        if not self.initialized[item["s"]]:
-            self._buff[item["s"]].append(item)
+        symbol = item["s"]
+        self._buff[symbol].append(item)
+        if not self.initialized[symbol]:
+            return
+        self._onmessage_update(item)
+
+    def _onmessage_update(self, item: Item) -> None:
+        symbol = item["s"]
+        last_update_id = self._last_update_id.get(symbol)
+        if last_update_id is not None and item["u"] <= last_update_id:
+            return
+
         for side in ("a", "b"):
             for row in item[side]:
                 if float(row[1]) != 0.0:
-                    self._update(
-                        [{"s": item["s"], "S": side, "p": row[0], "q": row[1]}]
-                    )
+                    self._update([{"s": symbol, "S": side, "p": row[0], "q": row[1]}])
                 else:
-                    self._delete([{"s": item["s"], "S": side, "p": row[0]}])
+                    self._delete([{"s": symbol, "S": side, "p": row[0]}])
+
+        self._last_update_id[symbol] = item["u"]
 
     def _onresponse(self, symbol: str, item: Item) -> None:
+        snapshot_update_id = item["lastUpdateId"]
         self._delete(self._find_and_delete({"s": symbol}))
         for side_ws, side_http in (("a", "asks"), ("b", "bids")):
             for row in item[side_http]:
                 self._insert([{"s": symbol, "S": side_ws, "p": row[0], "q": row[1]}])
+        self._last_update_id[symbol] = snapshot_update_id
         for msg in self._buff[symbol]:
-            if msg["U"] <= item["lastUpdateId"] and msg["u"] >= item["lastUpdateId"]:
-                self._onmessage(msg)
-        self._buff[symbol].clear()
+            self._onmessage_update(msg)
+        self._buff[symbol] = deque(
+            (msg for msg in self._buff[symbol] if msg["u"] > snapshot_update_id),
+            maxlen=self._BUFF_MAXLEN,
+        )
         self.initialized[symbol] = True
 
 

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1889,6 +1889,137 @@ async def server_coincheck() -> AsyncGenerator[str]:
         yield str(server.make_url(URL()))
 
 
+@pytest_asyncio.fixture
+async def server_binance_orderbook() -> AsyncGenerator[str]:
+    routes = web.RouteTableDef()
+
+    snapshots = {
+        "102": {
+            "lastUpdateId": 102,
+            "asks": [["100.0", "1.0"], ["101.0", "2.0"], ["102.0", "9.0"]],
+            "bids": [["99.0", "3.0"], ["98.0", "4.0"]],
+        },
+        "104": {
+            "lastUpdateId": 104,
+            "asks": [["101.0", "2.0"], ["102.0", "5.0"]],
+            "bids": [["99.0", "3.0"], ["98.0", "4.0"]],
+        },
+    }
+
+    async def depth(request: web.Request) -> web.Response:
+        snapshot_update_id = request.query.get("snapshot_update_id", "102")
+        return web.json_response(snapshots[snapshot_update_id])
+
+    routes.get("/api/v3/depth")(depth)
+    routes.get("/fapi/v1/depth")(depth)
+    routes.get("/dapi/v1/depth")(depth)
+
+    app = web.Application()
+    app.add_routes(routes)
+
+    async with TestServer(app) as server:
+        yield str(server.make_url(URL()))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("store_cls", "endpoint"),
+    [
+        pytest.param(
+            pybotters.BinanceSpotDataStore,
+            "/api/v3/depth",
+            id="spot",
+        ),
+        pytest.param(
+            pybotters.BinanceUSDSMDataStore,
+            "/fapi/v1/depth",
+            id="usdsm",
+        ),
+        pytest.param(
+            pybotters.BinanceCOINMDataStore,
+            "/dapi/v1/depth",
+            id="coinm",
+        ),
+    ],
+)
+async def test_binance_orderbook_reinitialize_replays_post_init_messages(
+    server_binance_orderbook: str,
+    store_cls,
+    endpoint: str,
+) -> None:
+    store = store_cls()
+    symbol = "BTCUSDT"
+
+    async with pybotters.Client(base_url=server_binance_orderbook) as client:
+        await store.initialize(
+            client.request(
+                "GET",
+                endpoint,
+                params={"symbol": symbol, "snapshot_update_id": "102"},
+            )
+        )
+
+        for message in (
+            {
+                "e": "depthUpdate",
+                "s": symbol,
+                "U": 103,
+                "u": 103,
+                "a": [["100.0", "0.0"]],
+                "b": [],
+            },
+            {
+                "e": "depthUpdate",
+                "s": symbol,
+                "U": 104,
+                "u": 104,
+                "a": [["102.0", "5.0"]],
+                "b": [],
+            },
+            {
+                "e": "depthUpdate",
+                "s": symbol,
+                "U": 105,
+                "u": 105,
+                "a": [],
+                "b": [["97.0", "7.0"]],
+            },
+        ):
+            store.onmessage(message)
+
+        await store.initialize(
+            client.request(
+                "GET",
+                endpoint,
+                params={"symbol": symbol, "snapshot_update_id": "104"},
+            )
+        )
+
+    store.onmessage(
+        {
+            "e": "depthUpdate",
+            "s": symbol,
+            "U": 106,
+            "u": 106,
+            "a": [["103.0", "8.0"]],
+            "b": [],
+        }
+    )
+
+    assert store.orderbook.sorted({"s": symbol}) == {
+        "a": [
+            {"s": symbol, "S": "a", "p": "101.0", "q": "2.0"},
+            {"s": symbol, "S": "a", "p": "102.0", "q": "5.0"},
+            {"s": symbol, "S": "a", "p": "103.0", "q": "8.0"},
+        ],
+        "b": [
+            {"s": symbol, "S": "b", "p": "99.0", "q": "3.0"},
+            {"s": symbol, "S": "b", "p": "98.0", "q": "4.0"},
+            {"s": symbol, "S": "b", "p": "97.0", "q": "7.0"},
+        ],
+    }
+
+
 @pytest.mark.asyncio
 async def test_coincheck_orderbook_initialize_replays_buffered_messages(
     server_coincheck: str,


### PR DESCRIPTION
## Summary
- retain post-init `depthUpdate` messages in the shared Binance orderbook buffer for future reinitialization
- replay only updates newer than the reapplied REST snapshot when rebuilding the orderbook
- add regression tests covering Spot, USDⓈ-M, and COIN-M

Closes #566
