### PR TITLE
Implement sequence-based diff buffering for bitbank `Depth` datastore

### DIFF
--- a/pybotters/models/bitbank.py
+++ b/pybotters/models/bitbank.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 from abc import ABC, abstractmethod
+from collections import defaultdict, deque
 from typing import TYPE_CHECKING, cast
 
 from ..store import DataStore, DataStoreCollection
@@ -76,9 +77,14 @@ class Transactions(DataStore):
 
 class Depth(DataStore):
     _KEYS = ["pair", "side", "price"]
+    _BUFF_MAXLEN = 8000
 
     def _init(self) -> None:
         self.timestamp: int | None = None
+        self._buff: defaultdict[str, deque[dict]] = defaultdict(
+            lambda: deque(maxlen=Depth._BUFF_MAXLEN)
+        )
+        self._sequence_id: dict[str, int] = {}
 
     def sorted(
         self, query: Item | None = None, limit: int | None = None
@@ -92,19 +98,8 @@ class Depth(DataStore):
             limit=limit,
         )
 
-    def _onmessage(self, room_name: str, data: dict[str, object]) -> None:
-        if "whole" in room_name:
-            pair = room_name.replace("depth_whole_", "")
-            result = self.find({"pair": pair})
-            self._delete(result)
-            tuples = (("bids", "bids"), ("asks", "asks"))
-            self.timestamp = cast("int", data["timestamp"])
-        else:
-            pair = room_name.replace("depth_diff_", "")
-            tuples = (("b", "bids"), ("a", "asks"))
-            self.timestamp = cast("int", data["t"])
-
-        for side_item, side in tuples:
+    def _apply_diff(self, pair: str, data: dict) -> None:
+        for side_item, side in (("b", "bids"), ("a", "asks")):
             for item in cast("list[list[str]]", data[side_item]):
                 if item[1] != "0":
                     self._update(
@@ -119,6 +114,47 @@ class Depth(DataStore):
                     )
                 else:
                     self._delete([{"pair": pair, "side": side, "price": item[0]}])
+
+    def _onmessage(self, room_name: str, data: dict[str, object]) -> None:
+        if "whole" in room_name:
+            pair = room_name.replace("depth_whole_", "")
+            snapshot_seq = int(cast("str", data["sequenceId"]))
+            result = self.find({"pair": pair})
+            self._delete(result)
+            for side_item, side in (("bids", "bids"), ("asks", "asks")):
+                for item in cast("list[list[str]]", data[side_item]):
+                    if item[1] != "0":
+                        self._update(
+                            [
+                                {
+                                    "pair": pair,
+                                    "side": side,
+                                    "price": item[0],
+                                    "amount": item[1],
+                                }
+                            ]
+                        )
+            for msg in self._buff[pair]:
+                if int(msg["s"]) > snapshot_seq:
+                    self._apply_diff(pair, msg)
+            self._buff[pair] = deque(
+                (m for m in self._buff[pair] if int(m["s"]) > snapshot_seq),
+                maxlen=Depth._BUFF_MAXLEN,
+            )
+            self._sequence_id[pair] = max(
+                snapshot_seq,
+                max((int(m["s"]) for m in self._buff[pair]), default=snapshot_seq),
+            )
+            self.timestamp = cast("int", data["timestamp"])
+        else:
+            pair = room_name.replace("depth_diff_", "")
+            self._buff[pair].append(cast("dict", data))
+            s = int(cast("str", data["s"]))
+            if pair in self._sequence_id and s <= self._sequence_id[pair]:
+                return
+            self._apply_diff(pair, cast("dict", data))
+            self._sequence_id[pair] = s
+            self.timestamp = cast("int", data["t"])
 
 
 class Ticker(DataStore):

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -2632,3 +2632,165 @@ def test_coincheck_private_order_market() -> None:
     )
 
     assert store.order.find() == []
+
+
+def test_bitbank_depth_sequence_replay() -> None:
+    """Verify that depth_whole replays only buffered diffs with s > sequenceId.
+
+    Per bitbank docs, the correct algorithm is:
+      1. Buffer ALL depth_diff messages (each carries field ``s``).
+      2. When depth_diff arrives, apply it immediately AND keep in buffer.
+      3. When depth_whole arrives (carries ``sequenceId``):
+         - Replace the local book with the snapshot.
+         - Replay buffered diffs whose ``s > sequenceId`` in ascending order.
+         - Discard diffs with ``s <= sequenceId``.
+
+    Docs example:
+      diff{s=3}, diff{s=5}, diff{s=6}, diff{s=8}, whole{sequenceId=5}
+      → Apply whole, then diff{s=6}, then diff{s=8}; ignore diff{s=3},diff{s=5}.
+    """
+    import json
+
+    store = pybotters.bitbankDataStore()
+    pair = "btc_jpy"
+
+    def _whole_msg(
+        asks: list[list[str]],
+        bids: list[list[str]],
+        ts: int,
+        sequence_id: str,
+    ) -> str:
+        return "42" + json.dumps(
+            [
+                "message",
+                {
+                    "room_name": f"depth_whole_{pair}",
+                    "message": {
+                        "data": {
+                            "asks": asks,
+                            "bids": bids,
+                            "timestamp": ts,
+                            "sequenceId": sequence_id,
+                        }
+                    },
+                },
+            ]
+        )
+
+    def _diff_msg(
+        a: list[list[str]],
+        b: list[list[str]],
+        t: int,
+        s: str,
+    ) -> str:
+        return "42" + json.dumps(
+            [
+                "message",
+                {
+                    "room_name": f"depth_diff_{pair}",
+                    "message": {
+                        "data": {
+                            "a": a,
+                            "b": b,
+                            "t": t,
+                            "s": s,
+                        }
+                    },
+                },
+            ]
+        )
+
+    # ---------------------------------------------------------------
+    # Scenario 1:  docs example  diff{3,5,6,8} then whole{seqId=5}
+    # ---------------------------------------------------------------
+
+    # diff s=3: set ask 200.0 @ 10.0  (should be IGNORED after whole)
+    store.onmessage(_diff_msg(a=[["200.0", "10.0"]], b=[], t=1001, s="3"))
+    # diff s=5: set bid 50.0 @ 20.0   (should be IGNORED after whole)
+    store.onmessage(_diff_msg(a=[], b=[["50.0", "20.0"]], t=1002, s="5"))
+    # diff s=6: set ask 105.0 @ 6.0   (should be REPLAYED after whole)
+    store.onmessage(_diff_msg(a=[["105.0", "6.0"]], b=[], t=1003, s="6"))
+    # diff s=8: set bid 94.0 @ 8.0    (should be REPLAYED after whole)
+    store.onmessage(_diff_msg(a=[], b=[["94.0", "8.0"]], t=1004, s="8"))
+
+    # whole with sequenceId="5"  — the snapshot base
+    store.onmessage(
+        _whole_msg(
+            asks=[["100.0", "1.0"], ["101.0", "2.0"]],
+            bids=[["99.0", "3.0"], ["98.0", "4.0"]],
+            ts=2000,
+            sequence_id="5",
+        )
+    )
+
+    result = store.depth.sorted({"pair": pair})
+
+    # Expected: snapshot + diff{s=6} + diff{s=8}, NOT diff{s=3} or diff{s=5}.
+    #
+    # snapshot asks: 100.0@1.0, 101.0@2.0
+    # + diff s=6 adds ask 105.0@6.0
+    # → asks: 100.0@1.0, 101.0@2.0, 105.0@6.0
+    #
+    # snapshot bids: 99.0@3.0, 98.0@4.0
+    # + diff s=8 adds bid 94.0@8.0
+    # → bids: 99.0@3.0, 98.0@4.0, 94.0@8.0
+    #
+    # diff s=3 (ask 200.0@10.0) must NOT be present
+    # diff s=5 (bid 50.0@20.0) must NOT be present
+    assert result == {
+        "asks": [
+            {"pair": pair, "side": "asks", "price": "100.0", "amount": "1.0"},
+            {"pair": pair, "side": "asks", "price": "101.0", "amount": "2.0"},
+            {"pair": pair, "side": "asks", "price": "105.0", "amount": "6.0"},
+        ],
+        "bids": [
+            {"pair": pair, "side": "bids", "price": "99.0", "amount": "3.0"},
+            {"pair": pair, "side": "bids", "price": "98.0", "amount": "4.0"},
+            {"pair": pair, "side": "bids", "price": "94.0", "amount": "8.0"},
+        ],
+    }, "Scenario 1 failed: snapshot + replay of s>5 diffs only"
+
+    # ---------------------------------------------------------------
+    # Scenario 2: second snapshot (re-init) with new sequenceId
+    # ---------------------------------------------------------------
+
+    # diff s=9: update ask 100.0 → amount 9.0  (should be IGNORED by next whole)
+    store.onmessage(_diff_msg(a=[["100.0", "9.0"]], b=[], t=3001, s="9"))
+    # diff s=11: add ask 110.0 @ 11.0  (should be REPLAYED after next whole)
+    store.onmessage(_diff_msg(a=[["110.0", "11.0"]], b=[], t=3002, s="11"))
+    # diff s=12: remove bid 98.0  (should be REPLAYED after next whole)
+    store.onmessage(_diff_msg(a=[], b=[["98.0", "0"]], t=3003, s="12"))
+
+    # second whole with sequenceId="10"
+    store.onmessage(
+        _whole_msg(
+            asks=[["100.0", "1.5"], ["101.0", "2.5"]],
+            bids=[["99.0", "3.5"], ["98.0", "4.5"]],
+            ts=4000,
+            sequence_id="10",
+        )
+    )
+
+    result2 = store.depth.sorted({"pair": pair})
+
+    # Expected: second snapshot + diff{s=11} + diff{s=12}; NOT diff{s=9}.
+    #
+    # snapshot asks: 100.0@1.5, 101.0@2.5
+    # + diff s=11 adds ask 110.0@11.0
+    # → asks: 100.0@1.5, 101.0@2.5, 110.0@11.0
+    #
+    # snapshot bids: 99.0@3.5, 98.0@4.5
+    # + diff s=12 removes bid 98.0
+    # → bids: 99.0@3.5
+    #
+    # diff s=9 (ask 100.0→9.0) must NOT be applied (s <= 10)
+    assert result2 == {
+        "asks": [
+            {"pair": pair, "side": "asks", "price": "100.0", "amount": "1.5"},
+            {"pair": pair, "side": "asks", "price": "101.0", "amount": "2.5"},
+            {"pair": pair, "side": "asks", "price": "110.0", "amount": "11.0"},
+        ],
+        "bids": [
+            {"pair": pair, "side": "bids", "price": "99.0", "amount": "3.5"},
+        ],
+    }, "Scenario 2 failed: second snapshot re-init with replay of s>10 diffs only"


### PR DESCRIPTION
## Summary

Fixes the bitbank `Depth` datastore to correctly handle the sequence-based synchronization algorithm described in the official bitbank WebSocket API docs.

## Problem

Per the official docs, clients must:
1. Buffer `depth_diff_{pair}` messages while waiting for `depth_whole_{pair}`
2. On snapshot arrival: replace the book and replay buffered diffs with `s > sequenceId`

Previously, pybotters applied diffs directly without buffering, so diffs arriving before the first snapshot (or between snapshots) could be lost or applied out of order.

## Changes

- `pybotters/models/bitbank.py`: Added `_buff` (deque per pair) and `_sequence_id` tracking to `Depth` class
  - Diff branch: append to buffer, skip stale diffs (`s <= sequenceId`)
  - Snapshot branch: replace book, replay buffered diffs with `s > sequenceId`, prune buffer
- `tests/test_datastore.py`: Added `test_bitbank_depth_sequence_replay` regression test

## Related

Closes #568